### PR TITLE
corrected snippet. ISO-8859-1 step now uses ISO-8859-1 instead of UTF-8

### DIFF
--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -92,7 +92,7 @@
               &lt;includes&gt;
                 &lt;include&gt;**/*.properties&lt;/include&gt;
               &lt;/includes&gt;
-              &lt;encoding&gt;UTF-8&lt;/encoding&gt;
+              &lt;encoding&gt;ISO-8859-1&lt;/encoding&gt;
             &lt;/configuration&gt;
           &lt;/execution&gt;
         &lt;/executions&gt;


### PR DESCRIPTION
The fourth example at http://www.mojohaus.org/license-maven-plugin/faq.html shows a tip how to deal with ISO-8859-1 files, but the snippet uses UTF-8 to convert.