### PR TITLE
Add m2e lifecycle mapping metadata.

### DIFF
--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <goals>
+          <goal>add-third-party</goal>
+          <goal>aggregate-add-third-party</goal>
+          <goal>check-file-header</goal>
+          <goal>comment-style-list</goal>
+          <goal>download-licenses</goal>
+          <goal>license-list</goal>
+          <goal>update-file-header</goal>
+          <goal>update-project-license</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
Add a lifecycle-mapping-metadata.xml file to the Maven plugin to keep Eclipse from complaining about the plugin.