### PR TITLE
ID mismatch when using SNAPSHOT versions #13

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -55,6 +55,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -454,6 +454,23 @@ public class DefaultThirdPartyTool
                                                String encoding, File missingFile )
         throws IOException
     {
+	    final Map<String, MavenProject> snapshots = new HashMap<String, MavenProject>();
+
+        // find snapshot dependencies
+        for (final Entry<String, MavenProject> entry : artifactCache.entrySet()) {
+            if (entry.getValue().getVersion().contains("SNAPSHOT")) {
+
+                snapshots.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        for (final Entry<String, MavenProject> snapshot : snapshots.entrySet()) {
+            // remove invalid entries, which contain timestamps in key
+            artifactCache.remove(snapshot.getKey());
+            // put corrected keys/entries into artifact cache
+            artifactCache.put(snapshot.getValue().getGroupId() + "--" + snapshot.getValue().getArtifactId() + "--"
+                + snapshot.getValue().getVersion(), snapshot.getValue());
+        }
         SortedSet<MavenProject> unsafeDependencies = getProjectsWithNoLicense( licenseMap, false );
 
         SortedProperties unsafeMappings = new SortedProperties( encoding );


### PR DESCRIPTION
According to the detailed description of the problem...
That should convert any timestamp notation of snapshots into snapshot-notations.
So the plugin does not differentiate between those.