### PR TITLE
add option to add empty line after the header

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
@@ -199,6 +199,20 @@ public abstract class AbstractFileHeaderMojo
     protected boolean addJavaLicenseAfterPackage;
 
     /**
+     * A flag to add an empty line after the header.
+     *
+     * <p>
+     * Checkstyle requires empty line between license header and package statement.
+     * If you are using addJavaLicenseAfterPackage=false it could make sense to set this to true.
+     * </p>
+     * <b>Note:</b> By default this property is set to {@code false} to keep old behavior.
+     *
+     * @since 1.9
+     */
+    @Parameter( property = "license.addEmptyLineAfterHeader", defaultValue = "false" )
+    protected boolean addEmptyLineAfterHeader;
+
+    /**
      * A flag to ignore no files to scan.
      *
      * <p>
@@ -449,6 +463,7 @@ public abstract class AbstractFileHeaderMojo
         filter.setUpdateCopyright( canUpdateCopyright );
         filter.setUpdateDescription( canUpdateDescription );
         filter.setUpdateLicense( canUpdateLicense );
+        filter.setEmptyLineAfterHeader( addEmptyLineAfterHeader );
 
         filter.setLog( getLog() );
         processor.setConfiguration( this );

--- a/src/main/java/org/codehaus/mojo/license/header/FileHeaderFilter.java
+++ b/src/main/java/org/codehaus/mojo/license/header/FileHeaderFilter.java
@@ -78,6 +78,11 @@ public abstract class FileHeaderFilter
     protected String fullHeaderContent;
 
     /**
+     * Flag sets to {@code true} if an empty line should be added after the header.
+     */
+    protected boolean emptyLineAfterHeader;
+
+    /**
      * maven logger.
      */
     protected Log log;
@@ -243,9 +248,11 @@ public abstract class FileHeaderFilter
     {
         if ( fullHeaderContent == null )
         {
-
             // box with comment
             fullHeaderContent = getTransformer().boxComment( getProcessTagHeaderContent(), true );
+            if (emptyLineAfterHeader) {
+                fullHeaderContent += '\n';
+            }
         }
         return fullHeaderContent;
     }
@@ -298,5 +305,13 @@ public abstract class FileHeaderFilter
         headerContent = null;
         processTagHeaderContent = null;
         fullHeaderContent = null;
+    }
+
+    public boolean isEmptyLineAfterHeader() {
+        return emptyLineAfterHeader;
+    }
+
+    public void setEmptyLineAfterHeader( boolean emptyLineAfterHeader ) {
+        this.emptyLineAfterHeader = emptyLineAfterHeader;
     }
 }


### PR DESCRIPTION
If you use this plugin to add the license header in front of the java
package line, there is no empty line inserted.
The package statement is in the next line after the closing header.
Checkstyle requires an empty line after a header / before the package
line.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>