### PR TITLE
add option to force an empty line after header

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
@@ -199,6 +199,20 @@ public abstract class AbstractFileHeaderMojo
     protected boolean addJavaLicenseAfterPackage;
 
     /**
+     * A flag to indicate if there should be an empty line after the header.
+     *
+     * <p>
+     * Checkstyle requires empty line between license header and package statement.
+     * If you are using addJavaLicenseAfterPackage=false it could make sense to set this to true.
+     * </p>
+     * <b>Note:</b> By default this property is set to {@code false} to keep old behavior.
+     *
+     * @since 1.9
+     */
+    @Parameter( property = "license.emptyLineAfterHeader", defaultValue = "false" )
+    protected boolean emptyLineAfterHeader;
+
+    /**
      * A flag to ignore no files to scan.
      *
      * <p>
@@ -512,6 +526,7 @@ public abstract class AbstractFileHeaderMojo
             aTransformer.setProcessStartTag( processStartTag );
             aTransformer.setProcessEndTag( processEndTag );
             aTransformer.setSectionDelimiter( sectionDelimiter );
+            aTransformer.setEmptyLineAfterHeader( emptyLineAfterHeader );
 
             if ( aTransformer instanceof JavaFileHeaderTransformer )
             {
@@ -781,7 +796,7 @@ public abstract class AbstractFileHeaderMojo
     }
 
     /**
-     * Process a given comment styl to all his detected files.
+     * Process a given comment style to all his detected files.
      *
      * @param commentStyle comment style to treat
      * @param filesToTreat files using this comment style to treat

--- a/src/main/java/org/codehaus/mojo/license/header/transformer/AbstractFileHeaderTransformer.java
+++ b/src/main/java/org/codehaus/mojo/license/header/transformer/AbstractFileHeaderTransformer.java
@@ -94,6 +94,11 @@ public abstract class AbstractFileHeaderTransformer
      */
     protected String commentLinePrefix;
 
+    /**
+     * Flag if there should be an empty line after the header.
+     */
+    protected boolean emptyLineAfterHeader;
+
     protected AbstractFileHeaderTransformer( String name, String description, String commentStartTag,
                                              String commentEndTag, String commentLinePrefix )
     {
@@ -244,6 +249,18 @@ public abstract class AbstractFileHeaderTransformer
      */
     public String addHeader( String header, String content )
     {
+        if ( emptyLineAfterHeader )
+        {
+            String[] contentSplit = content.split( "\\r?\\n", 2 );
+            if ( contentSplit.length > 0 )
+            {
+                final String line = contentSplit[0].trim();
+                if ( line.length() > 0 )
+                {
+                    return header + '\n' + content;
+                }
+            }
+        }
         return header + content;
     }
 
@@ -253,6 +270,16 @@ public abstract class AbstractFileHeaderTransformer
     public void setCommentLinePrefix( String commentLinePrefix )
     {
         this.commentLinePrefix = commentLinePrefix;
+    }
+
+    public boolean isEmptyLineAfterHeader()
+    {
+        return emptyLineAfterHeader;
+    }
+
+    public void setEmptyLineAfterHeader( boolean emptyLine )
+    {
+        this.emptyLineAfterHeader = emptyLine;
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/license/header/transformer/FileHeaderTransformer.java
+++ b/src/main/java/org/codehaus/mojo/license/header/transformer/FileHeaderTransformer.java
@@ -138,6 +138,13 @@ public interface FileHeaderTransformer
     String getCommentLinePrefix();
 
     /**
+     * Get flag if there should be an empty line after the header.
+     *
+     * @return if there should be an empty line after the header
+     */
+    boolean isEmptyLineAfterHeader();
+
+    /**
      * Adds the header.
      *
      * @param header  header to add
@@ -292,4 +299,11 @@ public interface FileHeaderTransformer
      * @param commentLinePrefix the new comment prefix line
      */
     void setCommentLinePrefix( String commentLinePrefix );
+
+    /**
+     * Set flag if there should be an empty line after the header.
+     *
+     * @param emptyLine flag if there should be an empty line after the header
+     */
+    void setEmptyLineAfterHeader( boolean emptyLine );
 }


### PR DESCRIPTION
If the header is in front of the package line ("addJavaLicenseAfterPackage=false") and you are using Checkstyle for your Java code, it complains that there should be an empty line in front of the package line.

Parameter: license.emptyLineAfterHeader

If this parameter is set to false (default) the behavior keeps the same as before.

If this parameter is set to true and there is a non-empty line after the header (the line is trimmed to check if empty) then an empty line is added between the header and the content.
