### PR TITLE
Skip unused dependencies when writing missing file

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
@@ -242,7 +242,12 @@ public class DefaultThirdPartyHelper
                                                               licenseMap );
 
                 // push back resolved unsafe mappings
-                unsafeMappings.putAll( resolvedUnsafeMapping );
+                for (Object coord : resolvedUnsafeMapping.keySet()) {
+                    String s = (String) coord;
+                    if (projectDependencies.containsKey(s)){
+                        unsafeMappings.put(s, resolvedUnsafeMapping.get(s));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
To avoid subsequent runs to complain about unused entries in the missing file.