### PR TITLE
Respect dual licensed dependencies.

### DIFF
--- a/src/it/dual-licensed-blacklist/invoker.properties
+++ b/src/it/dual-licensed-blacklist/invoker.properties
@@ -1,0 +1,24 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+# 
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean validate
+invoker.failureBehavior=fail-at-end
+invoker.buildResult=failure

--- a/src/it/dual-licensed-blacklist/pom.xml
+++ b/src/it/dual-licensed-blacklist/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as 
+  published by the Free Software Foundation, either version 3 of the 
+  License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+  
+  You should have received a copy of the GNU General Lesser Public 
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>dual-licensed-blacklisted</artifactId>
+    <version>1.0</version>
+
+    <name>License Test :: dual-licensed-blacklisted</name>
+
+    <url>no-url</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <license.verbose>true</license.verbose>
+    </properties>
+
+
+    <dependencies>
+        <!-- this one is dual-licensed under GPL and CDDL -->
+        <dependency>
+            <groupId>javax.xml.stream</groupId>
+            <artifactId>stax-api</artifactId>
+            <version>1.0-2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>@pom.version@</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dual-license</id>
+                        <goals>
+                            <goal>add-third-party</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <failIfWarning>true</failIfWarning>
+                            <excludedLicenses>GNU General Public Library</excludedLicenses>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/dual-licensed-blacklist/postbuild.groovy
+++ b/src/it/dual-licensed-blacklist/postbuild.groovy
@@ -1,0 +1,22 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+return true

--- a/src/it/dual-licensed-both-whitelisted/invoker.properties
+++ b/src/it/dual-licensed-both-whitelisted/invoker.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+# 
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean validate
+invoker.failureBehavior=fail-at-end

--- a/src/it/dual-licensed-both-whitelisted/pom.xml
+++ b/src/it/dual-licensed-both-whitelisted/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as 
+  published by the Free Software Foundation, either version 3 of the 
+  License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+  
+  You should have received a copy of the GNU General Lesser Public 
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>dual-licensed-both-whitelisted</artifactId>
+    <version>1.0</version>
+
+    <name>License Test :: dual-licensed-both-whitelisted</name>
+
+    <url>no-url</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <license.verbose>true</license.verbose>
+    </properties>
+
+
+    <dependencies>
+        <!-- this one is dual-licensed under GPL and CDDL -->
+        <dependency>
+            <groupId>javax.xml.stream</groupId>
+            <artifactId>stax-api</artifactId>
+            <version>1.0-2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>@pom.version@</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dual-license</id>
+                        <goals>
+                            <goal>add-third-party</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <failIfWarning>true</failIfWarning>
+                            <includedLicenses>GNU General Public Library|COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0</includedLicenses>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/dual-licensed-both-whitelisted/postbuild.groovy
+++ b/src/it/dual-licensed-both-whitelisted/postbuild.groovy
@@ -1,0 +1,22 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+return true

--- a/src/it/dual-licensed-none-whitelisted/invoker.properties
+++ b/src/it/dual-licensed-none-whitelisted/invoker.properties
@@ -1,0 +1,25 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+# 
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean validate
+invoker.failureBehavior=fail-at-end
+invoker.buildResult=failure
+license.verbose=true

--- a/src/it/dual-licensed-none-whitelisted/pom.xml
+++ b/src/it/dual-licensed-none-whitelisted/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as 
+  published by the Free Software Foundation, either version 3 of the 
+  License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+  
+  You should have received a copy of the GNU General Lesser Public 
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>dual-licensed-none-whitelisted</artifactId>
+    <version>1.0</version>
+
+    <name>License Test :: dual-licensed-none-whitelisted</name>
+
+    <url>no-url</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <license.verbose>true</license.verbose>
+    </properties>
+
+
+    <dependencies>
+        <!-- this one is dual-licensed under GPL and CDDL -->
+        <dependency>
+            <groupId>javax.xml.stream</groupId>
+            <artifactId>stax-api</artifactId>
+            <version>1.0-2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>@pom.version@</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dual-license</id>
+                        <goals>
+                            <goal>add-third-party</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <failIfWarning>true</failIfWarning>
+                            <includedLicenses>Foobar License</includedLicenses>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/dual-licensed-none-whitelisted/postbuild.groovy
+++ b/src/it/dual-licensed-none-whitelisted/postbuild.groovy
@@ -1,0 +1,22 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+return true

--- a/src/it/dual-licensed-one-whitelisted/invoker.properties
+++ b/src/it/dual-licensed-one-whitelisted/invoker.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+# 
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean validate
+invoker.failureBehavior=fail-at-end

--- a/src/it/dual-licensed-one-whitelisted/pom.xml
+++ b/src/it/dual-licensed-one-whitelisted/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as 
+  published by the Free Software Foundation, either version 3 of the 
+  License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+  
+  You should have received a copy of the GNU General Lesser Public 
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>dual-licensed-one-whitelisted</artifactId>
+    <version>1.0</version>
+
+    <name>License Test :: dual-licensed-one-whitelisted</name>
+
+    <url>no-url</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <license.verbose>true</license.verbose>
+    </properties>
+
+
+    <dependencies>
+        <!-- this one is dual-licensed under GPL and CDDL -->
+        <dependency>
+            <groupId>javax.xml.stream</groupId>
+            <artifactId>stax-api</artifactId>
+            <version>1.0-2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>@pom.version@</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>dual-license</id>
+                        <goals>
+                            <goal>add-third-party</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <failIfWarning>true</failIfWarning>
+                            <includedLicenses>GNU General Public Library</includedLicenses>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/dual-licensed-one-whitelisted/postbuild.groovy
+++ b/src/it/dual-licensed-one-whitelisted/postbuild.groovy
@@ -1,0 +1,22 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+return true

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -554,10 +554,10 @@ public abstract class AbstractAddThirdPartyMojo
 
             for ( String dependencyLicense : dependencyLicenses )
             {
-                getLog().info("Testing license '" + dependencyLicense + "'");
+                getLog().debug("Testing license '" + dependencyLicense + "'");
                 if ( !whiteLicenses.contains( dependencyLicense ) )
                 {
-                    getLog().info("Testing dependency license '" + dependencyLicense + "' against all other licenses");
+                    getLog().debug("Testing dependency license '" + dependencyLicense + "' against all other licenses");
 
                     for (MavenProject dependency : getLicenseMap().get(dependencyLicense)) {
                         getLog().debug("  testing dependency " + dependency);

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -566,7 +566,8 @@ public abstract class AbstractAddThirdPartyMojo
 
                         for (String otherLicense : dependencyLicenses) {
                             // skip this license if it is the same as the dependency license
-                            if (otherLicense.equals(dependencyLicense)) {
+                            // skip this license if it has no projects assigned
+                            if (otherLicense.equals(dependencyLicense) || getLicenseMap().get(dependencyLicense).isEmpty()) {
                                 continue;
                             }
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -549,15 +549,46 @@ public abstract class AbstractAddThirdPartyMojo
 
         if ( CollectionUtils.isNotEmpty( whiteLicenses ) )
         {
-            Set<String> licenses = getLicenseMap().keySet();
+            Set<String> dependencyLicenses = getLicenseMap().keySet();
             getLog().info( "Included licenses (whitelist): " + whiteLicenses );
 
-            for ( String license : licenses )
+            for ( String dependencyLicense : dependencyLicenses )
             {
-                if ( !whiteLicenses.contains( license ) )
+                getLog().info("Testing license '" + dependencyLicense + "'");
+                if ( !whiteLicenses.contains( dependencyLicense ) )
                 {
-                    //bad license found
-                    unsafeLicenses.add( license );
+                    getLog().info("Testing dependency license '" + dependencyLicense + "' against all other licenses");
+
+                    for (MavenProject dependency : getLicenseMap().get(dependencyLicense)) {
+                        getLog().debug("  testing dependency " + dependency);
+
+                        boolean forbiddenLicenseUsed = true;
+
+                        for (String otherLicense : dependencyLicenses) {
+                            // skip this license if it is the same as the dependency license
+                            if (otherLicense.equals(dependencyLicense)) {
+                                continue;
+                            }
+
+                            // skip this license if it isn't one of the whitelisted
+                            if (!whiteLicenses.contains(otherLicense)) {
+                                continue;
+                            }
+
+                            if (getLicenseMap().get(otherLicense).contains(dependency)) {
+                                getLog().info("License '" + dependencyLicense + "' for '" + dependency + "'is OK since it is also licensed under '" + otherLicense + "'");
+                                // this dependency is licensed under another license from white list
+                                forbiddenLicenseUsed = false;
+                                break;
+                            }
+                        }
+
+                        //bad license found
+                        if (forbiddenLicenseUsed) {
+                            unsafeLicenses.add(dependencyLicense);
+                            break;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
If a dependency has more than one license, check that at least one of these licenses is in white list and none is in the blacklist.