### PR TITLE
 Print strings using platform specific line endings

### DIFF
--- a/src/it/ISSUE-22/postbuild.groovy
+++ b/src/it/ISSUE-22/postbuild.groovy
@@ -39,32 +39,34 @@ def assertContains(file, content, expected)
     return true
 }
 
+def newLine = System.getProperty("line.separator")
+
 file = new File(basedir, 'src/main/resources/HelloWorld.html');
 assertExistsFile(file);
 
 content = file.text;
-assert assertContains(file, content, '<!DOCTYPE html>\n' +
+assert assertContains(file, content, '<!DOCTYPE html>' + newLine +
         '<!--');
 
 file = new File(basedir, 'src/main/resources/HelloWorld2.html');
 assertExistsFile(file);
 
 content = file.text;
-assert assertContains(file, content, '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">\n' +
+assert assertContains(file, content, '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">' + newLine +
         '<!--');
 
 file = new File(basedir, 'src/main/resources/HelloWorld3.html');
 assertExistsFile(file);
 
 content = file.text;
-assert assertContains(file, content, '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">\n' +
+assert assertContains(file, content, '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">' + newLine +
         '<!--');
 
 file = new File(basedir, 'src/main/resources/HelloWorld4.xhtml');
 assertExistsFile(file);
 
 content = file.text;
-assert assertContains(file, content, '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n' +
+assert assertContains(file, content, '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">' + newLine +
         '<!--');
 
 return true;

--- a/src/it/update-file-header-test-mojo/postbuild.groovy
+++ b/src/it/update-file-header-test-mojo/postbuild.groovy
@@ -60,6 +60,8 @@ def assertNotContains(file, content, expected)
   return true
 }
 
+def newLine = System.getProperty("line.separator")
+
 Calendar cal = Calendar.getInstance();
 cal.setTime(new Date());
 int currentYear = cal.get(Calendar.YEAR);
@@ -319,7 +321,7 @@ content = file.text;
 assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 file = new File(basedir, 'src/files/properties/test2.properties');
@@ -330,7 +332,7 @@ assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
 assert assertContains(file, content, '# #%L');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 
@@ -341,7 +343,7 @@ content = file.text;
 assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 
@@ -353,7 +355,7 @@ assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
 assert assertContains(file, content, '# #%L');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 //
@@ -368,7 +370,7 @@ assert content.startsWith('#!/bin/sh');
 assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 file = new File(basedir, 'src/files/properties/test2.sh');
@@ -379,7 +381,7 @@ assert content.startsWith('#!/bin/sh');
 assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 file = new File(basedir, 'src/files/properties/test.sh2');
@@ -390,7 +392,7 @@ assert content.startsWith('#!/bin/sh');
 assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 file = new File(basedir, 'src/files/properties/test2.sh2');
@@ -401,7 +403,7 @@ assert content.startsWith('#!/bin/sh');
 assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 //
@@ -669,7 +671,7 @@ content = file.text;
 assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 file = new File(basedir, 'child1/src/files/properties/test2.properties');
@@ -680,7 +682,7 @@ assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
 assert assertContains(file, content, '# #%L');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 //
@@ -695,7 +697,7 @@ assert content.startsWith('#!/bin/sh');
 assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 file = new File(basedir, 'child1/src/files/properties/test2.sh');
@@ -706,7 +708,7 @@ assert content.startsWith('#!/bin/sh');
 assert assertContains(file, content, 'Copyright (C)');
 assert assertContains(file, content, '# #%L');
 assert assertContains(file, content, '# #L%');
-assert assertNotContains(file, content, '# # \n');
+assert assertNotContains(file, content, '# # ' + newLine);
 assert assertContains(file, content, '$Id');
 
 //

--- a/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
@@ -1003,7 +1003,7 @@ public abstract class AbstractFileHeaderMojo
 
         if ( !isDryRun() )
         {
-            FileUtil.writeString( processFile, content, getEncoding() );
+            FileUtil.printString( processFile, content, getEncoding() );
         }
 
         FileState.add.addFile( file, result );

--- a/src/main/java/org/codehaus/mojo/license/UpdateProjectLicenseMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/UpdateProjectLicenseMojo.java
@@ -194,7 +194,7 @@ public class UpdateProjectLicenseMojo
         {
 
             // writes it root main license file
-            FileUtil.writeString( licenseFile, licenseContent, getEncoding() );
+            FileUtil.printString( licenseFile, licenseContent, getEncoding() );
         }
 
         if ( hasClassPath() )

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -611,7 +611,7 @@ public class DefaultThirdPartyTool
             log.info( content );
         }
 
-        FileUtil.writeString( thirdPartyFile, content, encoding );
+        FileUtil.printString( thirdPartyFile, content, encoding );
 
     }
 

--- a/src/main/java/org/codehaus/mojo/license/utils/FileUtil.java
+++ b/src/main/java/org/codehaus/mojo/license/utils/FileUtil.java
@@ -36,6 +36,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -239,25 +241,33 @@ public class FileUtil
     }
 
     /**
-     * Sauvegarde un contenu dans un fichier.
+     * Print content to file. This method ensures that a platform specific line ending is used.
      *
-     * @param file     le fichier a ecrire
-     * @param content  le contenu du fichier
-     * @param encoding l'encoding d'ecriture
+     * @param file     the file to write to
+     * @param content  the content to write
+     * @param encoding the encoding to write in
      * @throws IOException if IO pb
      */
-    public static void writeString( File file, String content, String encoding )
+    public static void printString(File file, String content, String encoding )
         throws IOException
     {
         createDirectoryIfNecessary( file.getParentFile() );
-        BufferedWriter out;
-        out = new BufferedWriter( new OutputStreamWriter( new FileOutputStream( file ), encoding ) );
+
+        BufferedReader in;
+        PrintWriter out;
+        in =  new BufferedReader(new StringReader(content));
+        out = new PrintWriter( new BufferedWriter( new OutputStreamWriter( new FileOutputStream( file ), encoding ) ));
         try
         {
-            IOUtil.copy( content, out );
+            String line;
+            while( ( line = in.readLine() ) != null )
+            {
+                out.println( line );
+            }
         }
         finally
         {
+            in.close();
             out.close();
         }
     }


### PR DESCRIPTION
 Resolves "issues different line endings on windows and linux #56" by  using a BufferedReader to take care of the possible line encodings and using a print writer to add the correct platform specific line endings.

 Renamed the method to printString to reflect the distinction between printing and writing as observed by java.

Apologies for any formatting mistakes. The formatting seems to be rather non-standard.

