### PR TITLE
Specify missing licenses on parent level of multi module project

### DIFF
--- a/src/it/PR-64-aggregate-unknown-license/THIRD-PARTY.properties
+++ b/src/it/PR-64-aggregate-unknown-license/THIRD-PARTY.properties
@@ -1,0 +1,1 @@
+org.codehaus.jettison--jettison--1.1=Custom defined license in PR-64

--- a/src/it/PR-64-aggregate-unknown-license/child1/pom.xml
+++ b/src/it/PR-64-aggregate-unknown-license/child1/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>PR-64-unknown-license-64-child1</artifactId>
+  <version>1.0</version>
+
+  <licenses>
+    <license>
+      <name>LGPL 3.0</name>
+      <url>http://jaxx.nuiton.org/v/latest/license.html</url>
+    </license>
+  </licenses>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.jettison</groupId>
+      <artifactId>jettison</artifactId>
+      <version>1.1</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/PR-64-aggregate-unknown-license/child2/pom.xml
+++ b/src/it/PR-64-aggregate-unknown-license/child2/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>PR-64-unknown-license-64-child2</artifactId>
+  <version>1.0</version>
+
+  <licenses>
+    <license>
+      <name>LGPL 3.0</name>
+      <url>http://topia.nuiton.org/v/latest/license.html</url>
+    </license>
+  </licenses>
+
+</project>

--- a/src/it/PR-64-aggregate-unknown-license/invoker.properties
+++ b/src/it/PR-64-aggregate-unknown-license/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean process-resources

--- a/src/it/PR-64-aggregate-unknown-license/pom.xml
+++ b/src/it/PR-64-aggregate-unknown-license/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>PR-64-unknown-license</artifactId>
+  <version>1.0</version>
+
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>child1</module>
+    <module>child2</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <failIfWarning>true</failIfWarning>
+        </configuration>
+        <executions>
+          <execution>
+            <id>aggregate</id>
+            <goals>
+              <goal>aggregate-add-third-party</goal>
+            </goals>
+            <phase>process-resources</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/PR-64-aggregate-unknown-license/postbuild.groovy
+++ b/src/it/PR-64-aggregate-unknown-license/postbuild.groovy
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit, Tony chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+def assertExistsFile(file) {
+    if (!file.exists() || file.isDirectory()) {
+        println(file.getAbsolutePath() + " file is missing or a directory.")
+        assert false
+    }
+    assert true
+}
+
+def assertContains(file, content, expected) {
+    if (!content.contains(expected)) {
+        println(expected + " was not found in file [" + file + "]\n :" + content)
+        return false
+    }
+    return true
+}
+
+file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY.txt');
+assertExistsFile(file);
+
+content = file.text;
+assert assertContains(file, content, '(Custom defined license in PR-64) Jettison (org.codehaus.jettison:jettison:1.1 - no url defined)');
+
+return true;

--- a/src/main/java/org/codehaus/mojo/license/api/ThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/ThirdPartyTool.java
@@ -24,6 +24,8 @@ package org.codehaus.mojo.license.api;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
+import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.model.License;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.mojo.license.model.LicenseMap;
@@ -115,6 +117,10 @@ public interface ThirdPartyTool
     File resolvThirdPartyDescriptor( MavenProject project, ArtifactRepository localRepository,
                                      List<ArtifactRepository> repositories )
         throws ThirdPartyToolException;
+
+    File resolveMissingLicensesDescriptor(String groupId, String artifactId, String version,
+                                          ArtifactRepository localRepository, List<ArtifactRepository> repositories)
+            throws IOException, ArtifactResolutionException, ArtifactNotFoundException;
 
     /**
      * From the given {@code licenseMap}, obtain all the projects with no license.


### PR DESCRIPTION
We needed to be able to define missing licenses on the root level of a multi module pom. Since this was not possible, I created this pull request.
It is now possible to define these properties in a THIRD-PARTY.properties file on the parent level, or specify an artifact in which a properties file can be found with the missing licenses.

Two optional properties were added to the 'license:aggregate-add-third-party' goal

**aggregateMissingLicensesFile**
Load file supplying information for missing third party licenses from file.
* Default value is: ${project.basedir}/THIRD-PARTY.properties.
* User property is: license.aggregateMissingLicensesFile.

**aggregateMissingLicensesFileArtifact**
Load file supplying information for missing third party licenses from file. The plugin looks for a Maven artifact with coordinates of the form G:A:V. It will look for a file of type 'properties' and classifier 'third-party'.
* User property is: license.aggregateMissingLicensesFileArtifact.


Can you please give feedback on this one? 
