### PR TITLE
Allow download-licenses mojo to write license summary without downloading licenses

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -244,12 +244,6 @@ public abstract class AbstractDownloadLicensesMojo
         throws MojoExecutionException
     {
 
-        if ( offline )
-        {
-
-            getLog().warn( "Offline flag is on, download-licenses goal is skip." );
-            return;
-        }
         if ( isSkip() )
         {
             getLog().info( "skip flag is on, will skip goal." );
@@ -294,7 +288,10 @@ public abstract class AbstractDownloadLicensesMojo
             {
                 depProject = createDependencyProject( project );
             }
-            downloadLicenses( depProject );
+            if ( !offline )
+            {
+                downloadLicenses( depProject );
+            }
             depProjectLicenses.add( depProject );
         }
 


### PR DESCRIPTION
Removing the mojo skip when offline is set to true.
Preventing downloadLicenses method from being called when offline is true,
this way the summary will be built, without any accompanying licenses.