### PR TITLE
Fix wrong licence header in Windows

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/header/transformer/AbstractFileHeaderTransformer.java
+++ b/src/main/java/org/codehaus/mojo/license/header/transformer/AbstractFileHeaderTransformer.java
@@ -389,7 +389,7 @@ public abstract class AbstractFileHeaderTransformer
         {
             buffer.append( getCommentStartTag() ).append( LINE_SEPARATOR );
         }
-        for ( String line : header.split( LINE_SEPARATOR + "" ) )
+        for ( String line : header.split( "\\r?\\n" ) )
         {
             buffer.append( getCommentLinePrefix() );
             buffer.append( line );


### PR DESCRIPTION
When 'mvn license:update-file-header' in Windows get next result(example):

/*-
 * #%L
 * xdocreport-report-engine
 * %%
 * Copyright (C) 2016 - 2017 COMSOFT, JSC
 * %%
 * Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 * #L%
 */

String "for ( String line : header.split( "\\r?\\n" ) )" instead "for ( String line : header.split( LINE_SEPARATOR + "" ) )" fixed it.