### PR TITLE
Clarified doc for `fileTemplate` property in `add-third-party` mojo

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -230,7 +230,12 @@ public abstract class AbstractAddThirdPartyMojo
     /**
      * Template used to build the third-party file.
      * <p>
-     * (This template use freemarker).
+     * (This template uses freemarker).
+     * <p>
+     * <b>Note:</b> This property can either point to a file or a resource on
+     * the classpath. In case it points to a file and this plugin is used within
+     * a sub-module as part of a multi-module build, you need to make this path
+     * resolvable, e.g. by prepending {@code basedir}.
      *
      * @since 1.1
      */


### PR DESCRIPTION
Clarified aspect of being both a file and a resource on classpath which might require an absolute path in case of running mojo within a sub-module of a multi-module build. Ran into this problem this morning and wanted to fix in the code but didn't want to mess too much with `DefaultThirdPartyTool` or the `FreemarkerHelper`. It would have required to use an instance of `MavenProject` itself which felt a little too heavy-weight.