### PR TITLE
Override the identified during license-check #77

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -407,8 +407,6 @@ public abstract class AbstractAddThirdPartyMojo
             }
         }
 
-        overrideLicenses();
-
         getHelper().mergeLicenses( licenseMerges, licenseMap );
     }
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -1,5 +1,14 @@
 package org.codehaus.mojo.license;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+
 /*
  * #%L
  * License Maven Plugin
@@ -7,16 +16,16 @@ package org.codehaus.mojo.license;
  * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
  * %%
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public 
+ *
+ * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
@@ -43,15 +52,6 @@ import org.codehaus.mojo.license.utils.FileUtil;
 import org.codehaus.mojo.license.utils.MojoHelper;
 import org.codehaus.mojo.license.utils.SortedProperties;
 import org.codehaus.mojo.license.utils.StringToList;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.SortedSet;
 
 /**
  * Abstract mojo for all third-party mojos.
@@ -407,6 +407,8 @@ public abstract class AbstractAddThirdPartyMojo
             }
         }
 
+        overrideLicenses();
+
         getHelper().mergeLicenses( licenseMerges, licenseMap );
     }
 
@@ -685,6 +687,12 @@ public abstract class AbstractAddThirdPartyMojo
         return safe;
     }
 
+    protected void overrideLicenses() throws IOException
+    {
+            LicenseMap licenseMap1 = getLicenseMap();
+            thirdPartyTool.overrideLicenses( licenseMap1, projectDependencies, getEncoding(), overrideFile );
+    }
+
     protected void writeThirdPartyFile()
             throws IOException
     {
@@ -693,7 +701,7 @@ public abstract class AbstractAddThirdPartyMojo
         {
 
             LicenseMap licenseMap1 = getLicenseMap();
-            thirdPartyTool.overrideLicenses( licenseMap1, projectDependencies, getEncoding(), overrideFile );
+
             if ( sortArtifactByName )
             {
                 licenseMap1 = licenseMap.toLicenseMapOrderByName();

--- a/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
@@ -1,5 +1,14 @@
 package org.codehaus.mojo.license;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+
 /*
  * #%L
  * License Maven Plugin
@@ -7,16 +16,16 @@ package org.codehaus.mojo.license;
  * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
  * %%
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public 
+ *
+ * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
@@ -38,15 +47,6 @@ import org.codehaus.mojo.license.model.LicenseMap;
 import org.codehaus.mojo.license.utils.FileUtil;
 import org.codehaus.mojo.license.utils.MojoHelper;
 import org.codehaus.mojo.license.utils.SortedProperties;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedMap;
-import java.util.SortedSet;
 
 /**
  * Goal to generate the third-party license file.
@@ -228,6 +228,7 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
     protected void doAction()
             throws Exception
     {
+        overrideLicenses();
 
         boolean unsafe = checkUnsafeDependencies();
 

--- a/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
@@ -1,5 +1,11 @@
 package org.codehaus.mojo.license;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.SortedSet;
+
 /*
  * #%L
  * License Maven Plugin
@@ -7,16 +13,16 @@ package org.codehaus.mojo.license;
  * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
  * %%
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public 
+ *
+ * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
@@ -34,12 +40,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingException;
 import org.codehaus.mojo.license.model.LicenseMap;
 import org.codehaus.mojo.license.utils.SortedProperties;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.SortedMap;
-import java.util.SortedSet;
 
 /**
  * This goal forks executions of the add-third-party goal for all the leaf projects
@@ -177,6 +177,7 @@ public class AggregatorAddThirdPartyMojo extends AbstractAddThirdPartyMojo
             resolveUnsafeDependenciesFromArtifact( groupId, artifactId, version );
         }
 
+        overrideLicenses();
 
         boolean unsafe = checkUnsafeDependencies();
 


### PR DESCRIPTION
I needed to resolve whitelist and blacklist using overridden licenses.

Just added method to encapsulate overrideLicenses call and invoked in both add-third-party and aggregate-add-third-party before license checkup