### PR TITLE
Add trimHeaderLine option

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
@@ -189,6 +189,19 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
     private boolean emptyLineAfterHeader;
 
     /**
+     * A flag to indicate if there should be an empty line after the header.
+     * <p>
+     * Checkstyle usually requires no trailing whitespace.
+     * If it is the case it could make sense to set this to true
+     * </p>
+     * <b>Note:</b> By default this property is set to {@code false} to keep old behavior.
+     *
+     * @since 1.14
+     */
+    @Parameter( property = "license.trimHeaderLine", defaultValue = "false" )
+    private boolean trimHeaderLine;
+
+    /**
      * A flag to ignore no files to scan.
      * <p>
      * This flag will suppress the "No file to scan" warning. This will allow you to set the plug-in in the root pom of
@@ -477,6 +490,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
             aTransformer.setProcessEndTag( processEndTag );
             aTransformer.setSectionDelimiter( sectionDelimiter );
             aTransformer.setEmptyLineAfterHeader( emptyLineAfterHeader );
+            aTransformer.setTrimHeaderLine( trimHeaderLine );
 
             if ( aTransformer instanceof JavaFileHeaderTransformer )
             {

--- a/src/main/java/org/codehaus/mojo/license/header/transformer/AbstractFileHeaderTransformer.java
+++ b/src/main/java/org/codehaus/mojo/license/header/transformer/AbstractFileHeaderTransformer.java
@@ -99,6 +99,11 @@ public abstract class AbstractFileHeaderTransformer
      */
     private boolean emptyLineAfterHeader;
 
+    /**
+     * Flag if line should be trimmed when boxed
+     */
+    private boolean trimHeaderLine;
+
     protected AbstractFileHeaderTransformer( String name, String description, String commentStartTag,
                                              String commentEndTag, String commentLinePrefix )
     {
@@ -283,9 +288,25 @@ public abstract class AbstractFileHeaderTransformer
     /**
      * {@inheritDoc}
      */
-    public void setEmptyLineAfterHeader( boolean emptyLine )
+    public void setEmptyLineAfterHeader( boolean trimLine )
     {
-        this.emptyLineAfterHeader = emptyLine;
+        this.emptyLineAfterHeader = trimLine;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isTrimHeaderLine()
+    {
+        return trimHeaderLine;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setTrimHeaderLine( boolean trimLine )
+    {
+        this.emptyLineAfterHeader = trimLine;
     }
 
     /**
@@ -391,8 +412,17 @@ public abstract class AbstractFileHeaderTransformer
         }
         for ( String line : header.split( "\\r?\\n" ) )
         {
-            buffer.append( getCommentLinePrefix() );
-            buffer.append( line );
+            if ( trimHeaderLine )
+            {
+              StringBuilder lineBuffer = new StringBuilder();
+              lineBuffer.append( getCommentLinePrefix() );
+              lineBuffer.append( line );
+              buffer.append(StringUtils.stripEnd(lineBuffer.toString(), null));
+            }
+            else {
+               buffer.append( getCommentLinePrefix() );
+               buffer.append( line );
+            }
             buffer.append( LINE_SEPARATOR );
         }
         if ( withTags )

--- a/src/main/java/org/codehaus/mojo/license/header/transformer/FileHeaderTransformer.java
+++ b/src/main/java/org/codehaus/mojo/license/header/transformer/FileHeaderTransformer.java
@@ -140,6 +140,13 @@ public interface FileHeaderTransformer
     boolean isEmptyLineAfterHeader();
 
     /**
+     * Get flag if header line should be right trimmed when written.
+     *
+     * @return if header line should be right trimmed when written
+     */
+    boolean isTrimHeaderLine();
+
+    /**
      * Adds the header.
      *
      * @param header  header to add
@@ -301,4 +308,11 @@ public interface FileHeaderTransformer
      * @param emptyLine flag if there should be an empty line after the header
      */
     void setEmptyLineAfterHeader( boolean emptyLine );
+
+    /**
+     * Set flag if header line should be right trimmed when written.
+     *
+     * @param trimLine flag if header line should be right trimmed when written
+     */
+    void setTrimHeaderLine( boolean trimLine );
 }


### PR DESCRIPTION
Add trimHeaderLine option to update-file-header goal.
If the header contains an empty line, when boxed the output line
might contain trailing whitespace which might be rejected by
Checkstyle plugin for example.

The option will do a right trim before writing the line.