### PR TITLE
Added licenseMergesFile user property

### DIFF
--- a/src/it/CLTS-1881-with-merges/consume-db/pom.xml
+++ b/src/it/CLTS-1881-with-merges/consume-db/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2012 - Benson Margulies
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as 
+  published by the Free Software Foundation, either version 3 of the 
+  License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+  
+  You should have received a copy of the GNU General Lesser Public 
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>test-add-third-party-global-db-consume-db</artifactId>
+
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-add-third-party-global-db</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+
+  <name>License Test :: global-db - consume</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <license.verbose>true</license.verbose>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>license-maven-plugin</artifactId>
+      <classifier>test-third-party</classifier>
+      <type>license.properties</type>
+      <version>@pom.version@</version>
+    </dependency>
+      <dependency>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-oxm</artifactId>
+        <version>1.5.8</version>
+      </dependency>
+  </dependencies>
+</project>
+
+

--- a/src/it/CLTS-1881-with-merges/invoker.properties
+++ b/src/it/CLTS-1881-with-merges/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals =clean install license:aggregate-add-third-party -Dlicense.licenseMergesFile=licenses.merge
+invoker.failureBehavior=fail-at-end
+invoker.maven.version = 3.0 +

--- a/src/it/CLTS-1881-with-merges/licenses.merge
+++ b/src/it/CLTS-1881-with-merges/licenses.merge
@@ -1,0 +1,1 @@
+APACHE|The Apache Software License, Version 2.0

--- a/src/it/CLTS-1881-with-merges/pom.xml
+++ b/src/it/CLTS-1881-with-merges/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2012 - Benson Margulies
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-add-third-party-global-db</artifactId>
+    <version>@pom.version@</version>
+    <packaging>pom</packaging>
+    <name>License Test :: global-db</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <license.verbose>true</license.verbose>
+    </properties>
+    <modules>
+      <module>consume-db</module>
+    </modules>
+    <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>license-maven-plugin</artifactId>
+              <version>@pom.version@</version>
+              <configuration>
+                <useMissingFile>true</useMissingFile>
+                <includeTransitiveDependencies>false</includeTransitiveDependencies>
+                <licenseMerges>
+                    <licenseMerge>Apache Software Licenses|Apache Software License|ASL</licenseMerge>
+                </licenseMerges>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-site-plugin</artifactId>
+              <version>3.1</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/src/it/CLTS-1881-with-merges/postbuild.groovy
+++ b/src/it/CLTS-1881-with-merges/postbuild.groovy
@@ -1,0 +1,11 @@
+file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY.txt');
+assert file.exists();
+content = file.text;
+assert !content.contains('the project has no dependencies.');
+assert content.contains('(APACHE) Spring O/X Mapping (org.springframework.ws:spring-oxm:1.5.8 - no url defined)');
+
+file = new File(basedir, 'build.log');
+assert file.exists();
+content = file.text;
+assert content.contains('licenseMerges will be overridden by licenseMergesFile.');
+return true;

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.FileUtils;
 
 /*
  * #%L
@@ -34,6 +32,7 @@ import org.apache.commons.io.FileUtils;
  */
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
 
 /*
  * #%L
@@ -104,7 +106,7 @@ public abstract class AbstractAddThirdPartyMojo
      * @since 1.1
      */
     @Parameter( property = "license.acceptPomPackaging", defaultValue = "false" )
- boolean acceptPomPackaging;
+    boolean acceptPomPackaging;
 
     /**
      * A filter to exclude some scopes.
@@ -228,10 +230,20 @@ public abstract class AbstractAddThirdPartyMojo
      * &lt;/licenseMerges&gt;
      * &lt;/pre&gt;
      *
+     * <b>Note:</b> This option will be overridden by {@link #licenseMergesFile} if it is used by command line.
      * @since 1.0
      */
     @Parameter
     List<String> licenseMerges;
+
+    /**
+     * The file with the merge licenses in order to be used by command line.
+     * <b>Note:</b> This option overrides {@link #licenseMerges}.
+     *
+     * @since 1.15
+     */
+    @Parameter( property = "license.licenseMergesFile" )
+    String licenseMergesFile;
 
     /**
      * To specify some licenses to include.
@@ -526,6 +538,12 @@ public abstract class AbstractAddThirdPartyMojo
 
         licenseMap = getHelper().createLicenseMap( projectDependencies );
 
+        if (licenseMergesFile != null) {
+            getLog().warn("");
+            getLog().warn("licenseMerges will be overridden by licenseMergesFile.");
+            getLog().warn("");
+            licenseMerges = FileUtils.readLines(new File(licenseMergesFile), "utf-8");
+        }
     }
 
     void consolidate() throws IOException, ArtifactNotFoundException, ArtifactResolutionException, MojoFailureException, ProjectBuildingException, ThirdPartyToolException {
@@ -608,6 +626,11 @@ public abstract class AbstractAddThirdPartyMojo
     File getOverrideFile()
     {
         return overrideFile;
+    }
+
+    String getLicenseMergesFile()
+    {
+        return licenseMergesFile;
     }
 
     SortedProperties getUnsafeMappings()

--- a/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
@@ -425,6 +425,7 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
         remoteRepositories = mojo.remoteRepositories;
         dependencies = new HashSet<Artifact>(mavenProject.getDependencies());
         licenseMerges = mojo.licenseMerges;
+        licenseMergesFile = mojo.licenseMergesFile;
         includedLicenses = mojo.includedLicenses;
         excludedLicenses = mojo.excludedLicenses;
         bundleThirdPartyPath = mojo.bundleThirdPartyPath;


### PR DESCRIPTION
I need to be able to define **licenseMerges**  as User property by command line to avoid touching the pom.xml file.

One optional properties was added to the 'license:add-third-party' and therefore 'license:aggregate-add-third-party'

**licenseMergesFile**
Load file supplying information for merging licenses in final file. If defined then it gets precedence to the licenseMerges property.
_User_ property is_: license.licenseMergesFile.

What do you think? Is this something others might get benefits?

Thanks