### PR TITLE
Fix #117 Add possibility to include/exclude types

### DIFF
--- a/src/it/add-third-party-excluded-included/pom.xml
+++ b/src/it/add-third-party-excluded-included/pom.xml
@@ -63,6 +63,12 @@
       <version>4.8.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-ejb-client-bom</artifactId>
+      <type>pom</type>
+      <version>9.0.1.Final</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -172,6 +178,30 @@
               <excludedGroups>org\.nuiton</excludedGroups>
               <excludedArtifacts>nuiton-i18n</excludedArtifacts>
               <thirdPartyFilename>thirdWithoutGroupWithoutArtifact.txt</thirdPartyFilename>
+            </configuration>
+          </execution>
+          <execution>
+            <id>exclude-pom</id>
+            <goals>
+              <goal>add-third-party</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <excludedGroups>org\.wildfly\.checkstyle</excludedGroups>
+              <excludedTypes>pom</excludedTypes>
+              <thirdPartyFilename>thirdWithoutType.txt</thirdPartyFilename>
+            </configuration>
+          </execution>
+          <execution>
+            <id>include-pom</id>
+            <goals>
+              <goal>add-third-party</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <excludedGroups>org\.wildfly\.checkstyle</excludedGroups>
+              <includedTypes>pom</includedTypes>
+              <thirdPartyFilename>thirdWithType.txt</thirdPartyFilename>
             </configuration>
           </execution>
         </executions>

--- a/src/it/add-third-party-excluded-included/postbuild.groovy
+++ b/src/it/add-third-party-excluded-included/postbuild.groovy
@@ -100,4 +100,27 @@ assert !content.contains('org.nuiton.i18n:nuiton-i18n:1.2.2');
 assert !content.contains('org.nuiton:maven-helper-plugin');
 assert content.contains('junit:junit:4.8.2');
 
+
+file = new File(basedir, 'target/generated-sources/license/thirdWithoutType.txt');
+assert file.exists();
+content = file.text;
+assert !content.contains('The project has no dependencies.');
+assert content.contains('commons-logging:commons-logging:1.1.1');
+assert content.contains('org.nuiton:nuiton-utils:1.4');
+assert content.contains('org.nuiton.i18n:nuiton-i18n:1.2.2');
+assert content.contains('org.nuiton:maven-helper-plugin');
+assert !content.contains('org.wildfly:wildfly-ejb-client-bom:9.0.1.Final');
+assert content.contains('junit:junit:4.8.2');
+
+file = new File(basedir, 'target/generated-sources/license/thirdWithType.txt');
+assert file.exists();
+content = file.text;
+assert !content.contains('The project has no dependencies.');
+assert !content.contains('commons-logging:commons-logging:1.1.1');
+assert !content.contains('org.nuiton:nuiton-utils:1.4');
+assert !content.contains('org.nuiton.i18n:nuiton-i18n:1.2.2');
+assert !content.contains('org.nuiton:maven-helper-plugin');
+assert content.contains('org.wildfly:wildfly-ejb-client-bom:9.0.1.Final');
+assert !content.contains('junit:junit:4.8.2');
+
 return true;

--- a/src/it/download-licenses-include-exclude-types/invoker.properties
+++ b/src/it/download-licenses-include-exclude-types/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean validate

--- a/src/it/download-licenses-include-exclude-types/pom.xml
+++ b/src/it/download-licenses-include-exclude-types/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license</groupId>
+  <artifactId>it-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Integration Test</name>
+  <url>http://maven.apache.org</url>
+  <description>
+    Check default execution.
+  </description>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-ejb-client-bom</artifactId>
+      <type>pom</type>
+      <version>9.0.1.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <id>exclude-pom</id>
+            <goals>
+              <goal>download-licenses</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <excludedGroups>org\.wildfly\.checkstyle</excludedGroups>
+              <excludedTypes>pom</excludedTypes>
+              <licensesOutputDirectory>${project.build.directory}/generated-resources/licenses1</licensesOutputDirectory>
+              <licensesOutputFile>${project.build.directory}/generated-resources/licenses1.xml</licensesOutputFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>include-pom</id>
+            <goals>
+              <goal>download-licenses</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <excludedGroups>org\.wildfly\.checkstyle</excludedGroups>
+              <includedTypes>pom</includedTypes>
+              <licensesOutputDirectory>${project.build.directory}/generated-resources/licenses2</licensesOutputDirectory>
+              <licensesOutputFile>${project.build.directory}/generated-resources/licenses2.xml</licensesOutputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/download-licenses-include-exclude-types/postbuild.groovy
+++ b/src/it/download-licenses-include-exclude-types/postbuild.groovy
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit, Tony chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+def assertExistsFile(file)
+{
+    if ( !file.exists() || file.isDirectory() )
+    {
+        println(file.getAbsolutePath() + " file is missing or a directory.")
+        assert false
+    }
+    assert true
+}
+
+def assertNotExistsFile(file)
+{
+  if ( file.exists() )
+  {
+    println(file.getAbsolutePath() + " file should not exists.")
+    assert false
+  }
+  assert true
+}
+
+file = new File(basedir, 'target/generated-resources/licenses1/common public license version 1.0 - cpl1.0.txt.html');
+assertExistsFile(file);
+
+file = new File(basedir, 'target/generated-resources/licenses2/common public license version 1.0 - cpl1.0.txt.html');
+assertNotExistsFile(file);
+
+file = new File(basedir, 'target/generated-resources/licenses1/lgpl - lgpl-2.1.txt');
+assertNotExistsFile(file);
+file = new File(basedir, 'target/generated-resources/licenses2/lgpl - lgpl-2.1.txt');
+assertExistsFile(file);
+
+file = new File(basedir, 'target/generated-resources/licenses1.xml');
+assertExistsFile(file);
+file = new File(basedir, 'target/generated-resources/licenses2.xml');
+assertExistsFile(file);
+
+return true;

--- a/src/it/download-licenses-include-exclude-types/src/main/java/org/codehaus/mojo/HelloWorld.java
+++ b/src/it/download-licenses-include-exclude-types/src/main/java/org/codehaus/mojo/HelloWorld.java
@@ -1,0 +1,15 @@
+package org.codehaus.mojo;
+
+public class HelloWorld
+{
+
+    /**
+     * @param args
+     */
+    public static void main( String[] args )
+    {
+        // TODO Auto-generated method stub
+
+    }
+
+}

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -123,6 +123,22 @@ public abstract class AbstractAddThirdPartyMojo
     String includedScopes;
 
     /**
+     * A filter to exclude some types.
+     *
+     * @since 1.15
+     */
+    @Parameter( property = "license.excludedTypes" )
+    String excludedTypes;
+
+    /**
+     * A filter to include only some types, if let empty then all types will be used (no filter).
+     *
+     * @since 1.15
+     */
+    @Parameter( property = "license.includedTypes")
+    String includedTypes;
+
+    /**
      * A filter to exclude some GroupIds
      * This is a regular expression that is applied to groupIds (not an ant pattern).
      *

--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -108,6 +108,22 @@ public abstract class AbstractDownloadLicensesMojo
     private String includedScopes;
 
     /**
+     * A filter to exclude some types.
+     *
+     * @since 1.15
+     */
+    @Parameter( property = "license.excludedTypes")
+    private String excludedTypes;
+
+    /**
+     * A filter to include only some types, if let empty then all types will be used (no filter).
+     *
+     * @since 1.15
+     */
+    @Parameter( property = "license.includedTypes", defaultValue = "" )
+    private String includedTypes;
+
+    /**
      * Settings offline flag (will not download anything if setted to true).
      *
      * @since 1.0
@@ -372,6 +388,22 @@ public abstract class AbstractDownloadLicensesMojo
     public List<String> getIncludedScopes()
     {
         return MojoHelper.getParams( includedScopes );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public List<String> getExcludedTypes()
+    {
+        return MojoHelper.getParams( excludedTypes );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public List<String> getIncludedTypes()
+    {
+        return MojoHelper.getParams( includedTypes );
     }
 
     // not used at the moment

--- a/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
@@ -90,6 +90,22 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport i
     private String includedScopes;
 
     /**
+     * A filter to exclude some types.
+     *
+     * @since 1.15
+     */
+    @Parameter( property = "license.excludedTypes")
+    private String excludedTypes;
+
+    /**
+     * A filter to include only some types, if let empty then all types will be used (no filter).
+     *
+     * @since 1.15
+     */
+    @Parameter( property = "license.includedTypes" )
+    private String includedTypes;
+
+    /**
      * A filter to exclude some GroupIds
      *
      * @since 1.1
@@ -399,6 +415,22 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport i
     public List<String> getIncludedScopes()
     {
         return MojoHelper.getParams( includedScopes );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public List<String> getExcludedTypes()
+    {
+        return MojoHelper.getParams( excludedTypes );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public List<String> getIncludedTypes()
+    {
+        return MojoHelper.getParams( includedTypes );
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
@@ -276,6 +276,22 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
     /**
      * {@inheritDoc}
      */
+    public List<String> getExcludedTypes()
+    {
+        return MojoHelper.getParams( excludedTypes );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public List<String> getIncludedTypes()
+    {
+        return MojoHelper.getParams( includedTypes );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public String getExcludedArtifacts()
     {
         return excludedArtifacts;

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultDependenciesTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultDependenciesTool.java
@@ -146,6 +146,8 @@ public class DefaultDependenciesTool
 
         List<String> includedScopes = configuration.getIncludedScopes();
         List<String> excludeScopes = configuration.getExcludedScopes();
+        List<String> includedTypes = configuration.getIncludedTypes();
+        List<String> excludeTypes = configuration.getExcludedTypes();
 
         boolean verbose = configuration.isVerbose();
 
@@ -186,6 +188,21 @@ public class DefaultDependenciesTool
             {
 
                 // in excluded scopes
+                continue;
+            }
+
+            String type = artifact.getType();
+            if ( CollectionUtils.isNotEmpty( includedTypes ) && !includedTypes.contains( type ) )
+            {
+
+                // not in included scopes
+                continue;
+            }
+
+            if ( excludeTypes.contains( type ) )
+            {
+
+                // in excluded types
                 continue;
             }
 

--- a/src/main/java/org/codehaus/mojo/license/api/MavenProjectDependenciesConfigurator.java
+++ b/src/main/java/org/codehaus/mojo/license/api/MavenProjectDependenciesConfigurator.java
@@ -57,6 +57,16 @@ public interface MavenProjectDependenciesConfigurator
     List<String> getExcludedScopes();
 
     /**
+     * @return list of types to include while loading dependencies, if {@code null} is setted, then include all types.
+     */
+    List<String> getIncludedTypes();
+
+    /**
+     * @return list of types to exclude while loading dependencies, if {@code null} is setted, then include all types.
+     */
+    List<String> getExcludedTypes();
+
+    /**
      * @return a pattern to include dependencies by thier {@code artificatId}, if {@code null} is setted then include
      *         all artifacts.
      */


### PR DESCRIPTION
This PR allows to include/exclude artifact types in add-third-party and download-licenses.
My use case is to exclude "pom" dependencies that are not relevant for the final license compilation since they do not provide artifacts themselves.