### PR TITLE
[121] Fix broken license link in some ITs

### DIFF
--- a/src/it/ISSUE-40/pom.xml
+++ b/src/it/ISSUE-40/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.1</version>
+      <version>4.12</version>
     </dependency>
   </dependencies>
 

--- a/src/it/ISSUE-40/postbuild.groovy
+++ b/src/it/ISSUE-40/postbuild.groovy
@@ -39,7 +39,7 @@ def assertNotExistsFile(file)
     assert true
 }
 
-file = new File(basedir, 'target/generated-resources/licenses/common public license version 1.0 - cpl1.0.txt.html');
+file = new File(basedir, 'target/generated-resources/licenses/eclipse public license 1.0 - epl-v10.html');
 assertExistsFile(file);
 
 file = new File(basedir, 'target/generated-resources/licenses/lesser general public license (lgpl) v 3.0 - lgpl-3.0.txt');

--- a/src/it/download-licenses-basic/pom.xml
+++ b/src/it/download-licenses-basic/pom.xml
@@ -12,12 +12,12 @@
   <description>
     Check default execution.
   </description>
-  
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.1</version>
+      <version>4.12</version>
     </dependency>
   </dependencies>
 

--- a/src/it/download-licenses-basic/postbuild.groovy
+++ b/src/it/download-licenses-basic/postbuild.groovy
@@ -39,7 +39,7 @@ def assertContains(file, content, expected)
     assert true
 }
 
-file = new File(basedir, 'target/generated-resources/licenses/common public license version 1.0 - cpl1.0.txt.html');
+file = new File(basedir, 'target/generated-resources/licenses/eclipse public license 1.0 - epl-v10.html');
 assertExistsFile(file);
 
 file = new File(basedir, 'target/generated-resources/licenses.xml');


### PR DESCRIPTION
See https://github.com/mojohaus/license-maven-plugin/issues/121

#### Changes
- JUnit 4.12 uses another [license file](https://github.com/junit-team/junit4/blame/r4.12/pom.xml#L20).
- Fix broken ITs.