### PR TITLE
Fixed ''remove-file-header' goal leaves the '\n' character, which should be avoided. #129'

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/RemoveFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/RemoveFileHeaderMojo.java
@@ -493,7 +493,7 @@ public class RemoveFileHeaderMojo extends AbstractLicenseNameMojo
             getLog().info( " - header was removed for " + file );
         }
 
-        String contentWithoutHeader = content.substring( 0, firstIndex ) + content.substring( lastIndex );
+        String contentWithoutHeader = content.substring( 0, firstIndex ) + content.substring( lastIndex + 1 );
 
         FileUtils.fileWrite( processFile, contentWithoutHeader );
         FileState.remove.addFile( file, result );

--- a/src/main/java/org/codehaus/mojo/license/header/transformer/AbstractFileHeaderTransformer.java
+++ b/src/main/java/org/codehaus/mojo/license/header/transformer/AbstractFileHeaderTransformer.java
@@ -305,9 +305,9 @@ public abstract class AbstractFileHeaderTransformer
     /**
      * {@inheritDoc}
      */
-    public void setEmptyLineAfterHeader( boolean trimLine )
+    public void setEmptyLineAfterHeader( boolean emptyLine )
     {
-        this.emptyLineAfterHeader = trimLine;
+        this.emptyLineAfterHeader = emptyLine;
     }
 
     /**
@@ -323,7 +323,7 @@ public abstract class AbstractFileHeaderTransformer
      */
     public void setTrimHeaderLine( boolean trimLine )
     {
-        this.emptyLineAfterHeader = trimLine;
+        this.trimHeaderLine = trimLine;
     }
 
     /**
@@ -429,7 +429,7 @@ public abstract class AbstractFileHeaderTransformer
         }
         for ( String line : header.split( "\\r?\\n" ) )
         {
-            if ( trimHeaderLine )
+            if ( isTrimHeaderLine() )
             {
               StringBuilder lineBuffer = new StringBuilder();
               lineBuffer.append( getCommentLinePrefix() );

--- a/src/test/java/org/codehaus/mojo/license/header/transformer/AbstractFileHeaderTransformerTest.java
+++ b/src/test/java/org/codehaus/mojo/license/header/transformer/AbstractFileHeaderTransformerTest.java
@@ -306,6 +306,15 @@ public class AbstractFileHeaderTransformerTest
         Assert.assertEquals( header, unboxedHeader );
     }
 
+    @Test
+    public void testSetTrimHeaderLine()
+    {
+        Assert.assertFalse(transformer.isTrimHeaderLine());
+
+        transformer.setTrimHeaderLine(true);
+        Assert.assertTrue(transformer.isTrimHeaderLine());
+    }
+
     public static void assertEquals( FileHeader model, FileHeader model2 )
     {
         Assert.assertEquals( model.getDescription(), model2.getDescription() );


### PR DESCRIPTION
Fixed ''remove-file-header' goal leaves the '\n' character, which should be avoided. #129'