### PR TITLE
Add functionality to export third party dependecies in csv format

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -466,6 +466,12 @@ public abstract class AbstractAddThirdPartyMojo
     boolean sortArtifactByName;
 
     /**
+     * A flag to create the third-party file as a csv file
+     */
+    @Parameter( property = "license.createCSV", defaultValue = "false")
+    boolean createCSV;
+
+    /**
      * Template used to build the third-party file.
      * <p>
      * (This template uses freemarker).
@@ -1004,7 +1010,15 @@ public abstract class AbstractAddThirdPartyMojo
             {
                 licenseMap1 = licenseMap.toLicenseMapOrderByName();
             }
-            thirdPartyTool.writeThirdPartyFile( licenseMap1, thirdPartyFile, isVerbose(), getEncoding(), fileTemplate );
+            if ( createCSV )
+            {
+              getLog().info("Creating CSV file");
+              thirdPartyTool.writeThirdPartyFile( licenseMap1, thirdPartyFile, isVerbose(), getEncoding(), fileTemplate );
+            }
+            else
+            {
+              thirdPartyTool.writeThirdPartyFile( licenseMap1, thirdPartyFile, isVerbose(), getEncoding(), fileTemplate );
+            }
         }
 
         if ( doGenerateBundle )

--- a/src/main/resources/org/codehaus/mojo/license/third-party-file-csv.ftl
+++ b/src/main/resources/org/codehaus/mojo/license/third-party-file-csv.ftl
@@ -1,0 +1,53 @@
+<#--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2012 Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+<#-- To render the third-party file.
+ Available context :
+
+ - dependencyMap a collection of Map.Entry with
+   key are dependencies (as a MavenProject) (from the maven project)
+   values are licenses of each dependency (array of string)
+
+ - licenseMap a collection of Map.Entry with
+   key are licenses of each dependency (array of string)
+   values are all dependencies using this license
+-->
+<#function licenseFormat licenses>
+    <#assign result = ""/>
+    <#list licenses as license>
+        <#assign result = result + "(" +license + ")"/>
+    </#list>
+    <#--<#assign result = result + "," />-->
+    <#return result>
+</#function>
+<#function artifactFormat p>
+        <#return p.groupId + ":" + p.artifactId + ";" + p.version + ";">
+</#function>
+
+<#if dependencyMap?size == 0>
+The project has no dependencies.
+<#else>
+<#list dependencyMap as e>
+    <#assign project = e.getKey()/>
+    <#assign licenses = e.getValue()/>
+${artifactFormat(project)}${licenseFormat(licenses)}
+</#list>
+</#if>


### PR DESCRIPTION
In order to create a machine readable dependency list that can be imported into e.g. excel, a parameter and an ftl template is added to create a csv file. It contains the groupid, artifactid, version and license(s).