### PR TITLE
Issue 145: Fix aggregate-add-third-party modifying project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-invoker-plugin</artifactId>
           <version>3.0.0</version>
+          <configuration>
+            <scriptVariables>
+              <projectVersion>${project.version}</projectVersion>
+            </scriptVariables>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.ec4j.maven</groupId>

--- a/src/it/ISSUE-145-2/README.txt
+++ b/src/it/ISSUE-145-2/README.txt
@@ -1,0 +1,3 @@
+Demonstrates that the aggregateAddThirdParty goal can handle long sibling project dependency chains in the same reactor, and that it resolves dependencies based on the right remote repositories list.
+
+The project has parent A and children B, C, D, E with B depending on C, C dependending on D and D depending on E. The D dependency has a custom repository specified, and a dependency from that repo. When the plugin generates the license list, it should pick up the license for the dependency from the custom repo. E has a custom license specified, which should also be picked up.

--- a/src/it/ISSUE-145-2/invoker.properties
+++ b/src/it/ISSUE-145-2/invoker.properties
@@ -1,0 +1,25 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+#
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean package
+invoker.failureBehavior=fail-fast
+#Disable the default settings.xml for integration tests. This test needs to always resolve dependencies from remote repositories, not from the local.
+invoker.profiles=!it-repo

--- a/src/it/ISSUE-145-2/pom.xml
+++ b/src/it/ISSUE-145-2/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>test-ISSUE-145-2</artifactId>
+  <version>@pom.version@</version>
+  <name>License Test :: ISSUE-145-2</name>
+  <packaging>pom</packaging>
+
+  <licenses>
+    <license>
+      <name>The GNU Lesser General Public License, Version 3.0</name>
+      <url>http://www.gnu.org/licenses/lgpl-3.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <license.verbose>true</license.verbose>
+    <license.sortByGroupIdAndArtifactId>true</license.sortByGroupIdAndArtifactId>
+    <licensesOutputFile>${project.build.directory}/licenses.xml</licensesOutputFile>
+  </properties>
+
+  <modules>
+    <module>submodule1</module>
+    <module>submodule2</module>
+    <module>submodule3</module>
+    <module>submodule4</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+          <executions>
+            <execution>
+              <id>aggregate-add-third-party</id>
+              <goals>
+                <goal>aggregate-add-third-party</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/src/it/ISSUE-145-2/postbuild.groovy
+++ b/src/it/ISSUE-145-2/postbuild.groovy
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+def assertExistsFile(file) {
+    if (!file.exists() || file.isDirectory()) {
+        println(file.getAbsolutePath() + " file is missing or a directory.")
+        assert false
+    }
+    assert true
+}
+
+def assertContains(file, content, expected) {
+    if (!content.contains(expected)) {
+        println(expected + " was not found in file [" + file + "]\n :" + content)
+        return false
+    }
+    return true
+}
+
+file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY.txt');
+assertExistsFile(file);
+
+content = file.text;
+assert assertContains(file, content, 'Eclipse Public License 1.0');
+assert assertContains(file, content, 'Custom ISSUE-145 license');
+
+return true;

--- a/src/it/ISSUE-145-2/submodule1/pom.xml
+++ b/src/it/ISSUE-145-2/submodule1/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-ISSUE-145-2</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
+
+  <artifactId>test-ISSUE-145-2-submodule1</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo.license.test</groupId>
+      <artifactId>test-ISSUE-145-2-submodule2</artifactId>
+      <version>@pom.version@</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/ISSUE-145-2/submodule2/pom.xml
+++ b/src/it/ISSUE-145-2/submodule2/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-ISSUE-145-2</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>test-ISSUE-145-2-submodule2</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo.license.test</groupId>
+      <artifactId>test-ISSUE-145-2-submodule3</artifactId>
+      <version>@pom.version@</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/ISSUE-145-2/submodule3/pom.xml
+++ b/src/it/ISSUE-145-2/submodule3/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-ISSUE-145-2</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>test-ISSUE-145-2-submodule3</artifactId>
+
+  <repositories>
+    <repository>
+      <id>clojars.org</id>
+      <url>https://repo.clojars.org</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+            <!-- This is not available on Central, which is essential to the test -->
+      <groupId>org.clojure-android</groupId>
+      <artifactId>tools.logging</artifactId>
+      <version>0.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.mojo.license.test</groupId>
+      <artifactId>test-ISSUE-145-2-submodule4</artifactId>
+      <version>@pom.version@</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/ISSUE-145-2/submodule4/pom.xml
+++ b/src/it/ISSUE-145-2/submodule4/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-ISSUE-145-2</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>test-ISSUE-145-2-submodule4</artifactId>
+
+  <licenses>
+    <license>
+      <name>Custom ISSUE-145 license</name>
+    </license>
+  </licenses>
+</project>

--- a/src/it/ISSUE-145/README.txt
+++ b/src/it/ISSUE-145/README.txt
@@ -1,0 +1,3 @@
+Demonstrates that the aggregateAddThirdParty goal does not cause Maven to drop dependencies.
+
+The project has parent A and children B and C with B depending on C. The bug in the plugin caused B to lose its dependency on C at build time, because the plugin modified Maven's list of dependencies for B. The test verifies that the dependency is preserved.

--- a/src/it/ISSUE-145/invoker.properties
+++ b/src/it/ISSUE-145/invoker.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+#
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean package
+invoker.failureBehavior=fail-fast

--- a/src/it/ISSUE-145/pom.xml
+++ b/src/it/ISSUE-145/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>test-ISSUE-145</artifactId>
+  <version>@pom.version@</version>
+  <name>License Test :: ISSUE-145</name>
+  <packaging>pom</packaging>
+
+  <licenses>
+    <license>
+      <name>The GNU Lesser General Public License, Version 3.0</name>
+      <url>http://www.gnu.org/licenses/lgpl-3.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <license.verbose>true</license.verbose>
+    <license.sortByGroupIdAndArtifactId>true</license.sortByGroupIdAndArtifactId>
+    <licensesOutputFile>${project.build.directory}/licenses.xml</licensesOutputFile>
+  </properties>
+
+  <modules>
+    <module>submodule1</module>
+    <module>submodule2</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+          <executions>
+            <execution>
+              <id>aggregate-add-third-party</id>
+              <goals>
+                <goal>aggregate-add-third-party</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/src/it/ISSUE-145/postbuild.groovy
+++ b/src/it/ISSUE-145/postbuild.groovy
@@ -1,0 +1,27 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+import java.util.jar.JarFile
+
+file = new JarFile(new File(basedir, 'submodule1/target/test-ISSUE-145-submodule1-' + projectVersion + '.jar'));
+expectedLibPath = 'org/codehaus/mojo/license/AnImportantDependency.class';
+assert file.getJarEntry(expectedLibPath) != null;
+return true;

--- a/src/it/ISSUE-145/submodule1/pom.xml
+++ b/src/it/ISSUE-145/submodule1/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-ISSUE-145</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>jar</packaging>
+
+  <artifactId>test-ISSUE-145-submodule1</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo.license.test</groupId>
+      <artifactId>test-ISSUE-145-submodule2</artifactId>
+      <version>@pom.version@</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+</project>

--- a/src/it/ISSUE-145/submodule1/src/main/java/org/codehaus/mojo/license/Application.java
+++ b/src/it/ISSUE-145/submodule1/src/main/java/org/codehaus/mojo/license/Application.java
@@ -1,0 +1,29 @@
+package org.codehaus.mojo.license;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2017 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+public class Application {
+
+    public static void main(String[] args) {
+    }
+}

--- a/src/it/ISSUE-145/submodule2/pom.xml
+++ b/src/it/ISSUE-145/submodule2/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-ISSUE-145</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>test-ISSUE-145-submodule2</artifactId>
+</project>

--- a/src/it/ISSUE-145/submodule2/src/main/java/org/codehaus/mojo/license/AnImportantDependency.java
+++ b/src/it/ISSUE-145/submodule2/src/main/java/org/codehaus/mojo/license/AnImportantDependency.java
@@ -1,0 +1,28 @@
+
+package org.codehaus.mojo.license;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2017 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+public class AnImportantDependency {
+
+}

--- a/src/it/ISSUE-80/pom.xml
+++ b/src/it/ISSUE-80/pom.xml
@@ -31,7 +31,7 @@
   <artifactId>test-ISSUE-59</artifactId>
   <version>@pom.version@</version>
 
-  <name>License Test :: ISSUE-59</name>
+  <name>License Test :: ISSUE-80</name>
   <packaging>jar</packaging>
 
   <licenses>

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import org.codehaus.mojo.license.api.DependenciesToolException;
 
 /**
  * Abstract mojo for all third-party mojos.
@@ -574,8 +575,9 @@ public abstract class AbstractAddThirdPartyMojo
      * Loads the dependencies of the project (as {@link MavenProject}, indexed by their gav.
      *
      * @return the map of dependencies of the maven project indexed by their gav.
+     * @throws DependenciesToolException if the dependencies could not be loaded
      */
-    protected abstract SortedMap<String, MavenProject> loadDependencies();
+    protected abstract SortedMap<String, MavenProject> loadDependencies() throws DependenciesToolException;
 
     /**
      * Creates the unsafe mapping (says dependencies with no license given by their pom).
@@ -583,12 +585,14 @@ public abstract class AbstractAddThirdPartyMojo
      * Can come from loaded missing file or from dependencies with no license at all.
      *
      * @return the map of usafe mapping indexed by their gav.
-     * @throws ProjectBuildingException if could not create maven porject for some dependencies
+     * @throws ProjectBuildingException if could not create maven project for some dependencies
      * @throws IOException              if could not load missing file
      * @throws ThirdPartyToolException  for third party tool error
+     * @throws DependenciesToolException if the dependencies could not be loaded
      */
     protected abstract SortedProperties createUnsafeMapping()
-      throws ProjectBuildingException, IOException, ThirdPartyToolException, MojoExecutionException;
+      throws ProjectBuildingException, IOException, ThirdPartyToolException,
+            MojoExecutionException, DependenciesToolException;
 
     // ----------------------------------------------------------------------
     // AbstractLicenseMojo Implementaton
@@ -674,7 +678,8 @@ public abstract class AbstractAddThirdPartyMojo
     }
 
     void consolidate() throws IOException, ArtifactNotFoundException, ArtifactResolutionException, MojoFailureException,
-                              ProjectBuildingException, ThirdPartyToolException, MojoExecutionException
+                              ProjectBuildingException, ThirdPartyToolException,
+                              MojoExecutionException, DependenciesToolException
     {
 
         unsafeDependencies = getHelper().getProjectsWithNoLicense( licenseMap );

--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
+import org.codehaus.mojo.license.api.ResolvedProjectDependencies;
 
 /**
  * Created on 23/05/16.
@@ -285,7 +286,9 @@ public abstract class AbstractDownloadLicensesMojo
 
     protected SortedMap<String, MavenProject> getDependencies( MavenProject project )
     {
-        return dependenciesTool.loadProjectDependencies( project, this, localRepository, remoteRepositories, null );
+        return dependenciesTool.loadProjectDependencies(
+                new ResolvedProjectDependencies( project.getArtifacts(), project.getDependencyArtifacts() ),
+                this, localRepository, remoteRepositories, null );
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
@@ -24,14 +24,13 @@ package org.codehaus.mojo.license;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
-import java.util.TreeMap;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -208,14 +207,8 @@ public class AggregatorAddThirdPartyMojo extends AbstractAddThirdPartyMojo
         }
 
         String addThirdPartyRoleHint = groupId + ":" + artifactId + ":" + version + ":" + "add-third-party";
-        Map<String, List<Dependency>> reactorProjectDependencies = new TreeMap<>();
-        for ( MavenProject reactorProject : this.reactorProjects )
-        {
-            reactorProjectDependencies.put( String.format( "%s:%s", reactorProject.getGroupId(),
-                    reactorProject.getArtifactId() ), reactorProject.getDependencies() );
-        }
 
-        for ( Object reactorProject : reactorProjects )
+        for ( MavenProject reactorProject : reactorProjects )
         {
             if ( getProject().equals( reactorProject ) )
             {
@@ -223,11 +216,10 @@ public class AggregatorAddThirdPartyMojo extends AbstractAddThirdPartyMojo
                 continue;
             }
 
-
             AddThirdPartyMojo mojo = (AddThirdPartyMojo) getSession()
                     .lookup( AddThirdPartyMojo.ROLE, addThirdPartyRoleHint );
 
-            mojo.initFromMojo( this, (MavenProject) reactorProject, reactorProjectDependencies );
+            mojo.initFromMojo( this, reactorProject, new ArrayList<>( this.reactorProjects ) );
 
             LicenseMap childLicenseMap = mojo.getLicenseMap();
             if ( isVerbose() )

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
@@ -150,10 +150,11 @@ public class DefaultThirdPartyHelper
     /**
      * {@inheritDoc}
      */
-    public SortedMap<String, MavenProject> loadDependencies( MavenProjectDependenciesConfigurator configuration )
+    public SortedMap<String, MavenProject> loadDependencies( MavenProjectDependenciesConfigurator configuration,
+                                                             ResolvedProjectDependencies dependencyArtifacts )
     {
-        return dependenciesTool.loadProjectDependencies( project, configuration, localRepository, remoteRepositories,
-                                                         getArtifactCache() );
+        return dependenciesTool.loadProjectDependencies( dependencyArtifacts, configuration, localRepository,
+                remoteRepositories, getArtifactCache() );
     }
 
     /**
@@ -217,11 +218,11 @@ public class DefaultThirdPartyHelper
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings( "unchecked" ) // project.getArtifacts()
     public SortedProperties createUnsafeMapping( LicenseMap licenseMap, File missingFile, String missingFileUrl,
                                                  boolean useRepositoryMissingFiles,
                                                  SortedSet<MavenProject> unsafeDependencies,
-                                                 SortedMap<String, MavenProject> projectDependencies )
+                                                 SortedMap<String, MavenProject> projectDependencies,
+                                                 Set<Artifact> dependencyArtifacts )
       throws ProjectBuildingException, IOException, ThirdPartyToolException, MojoExecutionException
     {
 
@@ -243,7 +244,7 @@ public class DefaultThirdPartyHelper
                 projects.removeAll( unsafeDependencies );
 
                 SortedProperties resolvedUnsafeMapping =
-                        loadThirdPartyDescriptorForUnsafeMapping( project.getArtifacts(), unsafeDependencies, projects,
+                        loadThirdPartyDescriptorForUnsafeMapping( dependencyArtifacts, unsafeDependencies, projects,
                                                                   licenseMap );
 
                 // push back resolved unsafe mappings (only for project dependencies)

--- a/src/main/java/org/codehaus/mojo/license/api/DependenciesTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DependenciesTool.java
@@ -22,9 +22,7 @@ package org.codehaus.mojo.license.api;
  * #L%
  */
 
-import java.util.Map;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 
 import java.util.List;
@@ -45,7 +43,7 @@ public interface DependenciesTool
      *
      * Result is given in a map where keys are unique artifact id
      *
-     * @param project            the project to scann
+     * @param dependencies       the project dependencies
      * @param configuration      the configuration
      * @param localRepository    local repository used to resolv dependencies
      * @param remoteRepositories remote repositories used to resolv dependencies
@@ -53,7 +51,7 @@ public interface DependenciesTool
      * @return the map of resolved dependencies indexed by their unique id.
      * @see MavenProjectDependenciesConfigurator
      */
-    SortedMap<String, MavenProject> loadProjectDependencies( MavenProject project,
+    SortedMap<String, MavenProject> loadProjectDependencies( ResolvedProjectDependencies dependencies,
                                                              MavenProjectDependenciesConfigurator configuration,
                                                              ArtifactRepository localRepository,
                                                              List<ArtifactRepository> remoteRepositories,
@@ -64,12 +62,12 @@ public interface DependenciesTool
      *
      * @param localRepository    local repository used to resolv dependencies
      * @param remoteRepositories remote repositories used to resolv dependencies
-     * @param project            the project to scann
-     * @param reactorProjectDependencies optional reactor projects dependencies indexed by their gav to resolve
-     *        artifacts without fork mode (means artifacts may not exist)
+     * @param project            the project to scan
+     * @param reactorProjectDependencies reactor projects. Optional, only relevant if there is more than one)
+     * @return the loaded project dependency artifacts
      * @throws DependenciesToolException if could not load project dependencies
      */
-    void loadProjectArtifacts( ArtifactRepository localRepository, List remoteRepositories, MavenProject project ,
-            Map<String, List<Dependency>> reactorProjectDependencies )
+    ResolvedProjectDependencies loadProjectArtifacts( ArtifactRepository localRepository, List remoteRepositories,
+            MavenProject project, List<MavenProject> reactorProjectDependencies )
         throws DependenciesToolException;
 }

--- a/src/main/java/org/codehaus/mojo/license/api/ResolvedProjectDependencies.java
+++ b/src/main/java/org/codehaus/mojo/license/api/ResolvedProjectDependencies.java
@@ -1,0 +1,63 @@
+package org.codehaus.mojo.license.api;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.maven.artifact.Artifact;
+
+/**
+ * Copies of the project's dependency sets. AddThirdParty needs to load dependencies only for the single project it is
+ * run for, while AggregateAddThirdParty needs to load dependencies for the parent project, as well as all child
+ * projects in the reactor.
+ *
+ * The aggregator goal replaces all reactor projects with their direct dependencies, to avoid trying to load artifacts
+ * for projects that haven't been built/published yet. This is necessary in cases where one child project A in a reactor
+ * depends on another project B in the same reactor. Since B is not necessarily built/published, the plugin needs to
+ * replace B with its dependencies when processing A. This field stores that modified view of the project's
+ * dependencies.
+ */
+public class ResolvedProjectDependencies
+{
+
+    private final Set<Artifact> allDependencies;
+    private final Set<Artifact> directDependencies;
+
+    public ResolvedProjectDependencies( Set<Artifact> allDependencies, Set<Artifact> directDependencies )
+    {
+        this.allDependencies = Collections.unmodifiableSet( new HashSet<>( allDependencies ) );
+        this.directDependencies = Collections.unmodifiableSet( new HashSet<>( directDependencies ) );
+    }
+
+    public Set<Artifact> getAllDependencies()
+    {
+        return allDependencies;
+    }
+
+    public Set<Artifact> getDirectDependencies()
+    {
+        return directDependencies;
+    }
+
+}

--- a/src/main/java/org/codehaus/mojo/license/api/ThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/ThirdPartyHelper.java
@@ -50,10 +50,12 @@ public interface ThirdPartyHelper
     /**
      * Load all dependencies given the configuration as {@link MavenProject}.
      *
-     * @param configuration the configuration of the project and include/exclude to do on his dependencies
+     * @param configuration the configuration of the project and include/exclude to do on its dependencies
+     * @param dependencyArtifacts the dependency artifacts of the project
      * @return the dictionary of loaded dependencies as {@link MavenProject} indexed by their gav.
      */
-    SortedMap<String, MavenProject> loadDependencies( MavenProjectDependenciesConfigurator configuration );
+    SortedMap<String, MavenProject> loadDependencies( MavenProjectDependenciesConfigurator configuration,
+                                                      ResolvedProjectDependencies dependencyArtifacts );
 
 
     /**
@@ -82,8 +84,8 @@ public interface ThirdPartyHelper
      * @param missingFile         location of an optional missing fille (says where you fix missing license).
      * @param missingFileUrl      location of an optional missing file extension that can be downloaded from some
      *                            resource hoster and that will be merged with the content of the missing file.
-     * @param projectDependencies project dependencies used to detect which dependencies in the missing file are unknown
-     *                            to the project.
+     * @param projectDependencies project dependencies used to detect which dependencies in the missing file
+     *                            are unknown to the project.
      * @return the map of all unsafe mapping
      * @throws IOException if could not load missing file
      */
@@ -144,6 +146,7 @@ public interface ThirdPartyHelper
      *                                  maven repositories
      * @param unsafeDependencies        all unsafe dependencies
      * @param projectDependencies       all project dependencies
+     * @param dependencyArtifacts       all project dependency artifacts
      * @return the loaded unsafe mapping
      * @throws ProjectBuildingException if could not build some dependencies maven project
      * @throws IOException              if could not load missing file
@@ -152,7 +155,8 @@ public interface ThirdPartyHelper
     SortedProperties createUnsafeMapping( LicenseMap licenseMap, File missingFile, String missingFileUrl,
                                           boolean useRepositoryMissingFiles,
                                           SortedSet<MavenProject> unsafeDependencies,
-                                          SortedMap<String, MavenProject> projectDependencies )
+                                          SortedMap<String, MavenProject> projectDependencies,
+                                          Set<Artifact> dependencyArtifacts )
       throws ProjectBuildingException, IOException, ThirdPartyToolException, MojoExecutionException;
 
     /**


### PR DESCRIPTION
Fixes https://github.com/mojohaus/license-maven-plugin/issues/145.

The issue occurs because the plugin modifies the MavenProject dependency lists in DefaultDependencyTool.loadProjectArtifacts. Dependencies may in some cases be removed if they belong to the same reactor as the current project.  

I've added a modified version of the reproduction code from https://github.com/jimonthebarn/maven-license-plugin-issue as a test.

The changes are attempting to preserve the current behavior of the plugin, while also not modifying the MavenProject fields.