### PR TITLE
Fix plurals in messages emitted for dependencies without license

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -879,12 +879,20 @@ public abstract class AbstractAddThirdPartyMojo
         if ( CollectionUtils.isNotEmpty( unsafeDeps ) )
         {
             Log log = getLog();
-            log.warn( "There is " + unsafeDeps.size() + " dependencies with no license :" );
-            for ( MavenProject dep : unsafeDeps )
+            if ( log.isWarnEnabled() )
             {
+                boolean plural = unsafeDeps.size() > 1;
+                String message = String.format( "There %s %d %s with no license :",
+                    plural ? "are" : "is",
+                    unsafeDeps.size(),
+                    plural ? "dependencies" : "dependency" );
+                log.warn( message );
+                for ( MavenProject dep : unsafeDeps )
+                {
 
-                // no license found for the dependency
-                log.warn( " - " + MojoHelper.getArtifactId( dep.getArtifact() ) );
+                    // no license found for the dependency
+                    log.warn( " - " + MojoHelper.getArtifactId( dep.getArtifact() ) );
+                }
             }
         }
     }

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -175,12 +175,20 @@ public class DefaultThirdPartyTool
             }
             else
             {
-                log.debug( "There is " + unsafeDependencies.size() + " dependencies with no license from poms : " );
-                for ( MavenProject dep : unsafeDependencies )
+                if ( log.isDebugEnabled() )
                 {
+                    boolean plural = unsafeDependencies.size() > 1;
+                    String message = String.format( "There %s %d %s with no license from poms :",
+                        plural ? "are" : "is",
+                        unsafeDependencies.size(),
+                        plural ? "dependencies" : "dependency" );
+                    log.debug( message );
+                    for ( MavenProject dep : unsafeDependencies )
+                    {
 
-                    // no license found for the dependency
-                    log.debug( " - " + MojoHelper.getArtifactId( dep.getArtifact() ) );
+                        // no license found for the dependency
+                        log.debug( " - " + MojoHelper.getArtifactId( dep.getArtifact() ) );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #149

Change-Id: Ie46be7830280f55778123213c16095d938cc4042
Signed-off-by: David Pursehouse <dpursehouse@collab.net>