### PR TITLE
Property licenseMergesUrl is not in 1.16; it's not yet released.

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -286,7 +286,7 @@ public abstract class AbstractAddThirdPartyMojo
      * Location of file with the merge licenses in order to be used by command line.
      * <b>Note:</b> This option overrides {@link #licenseMerges}.
      *
-     * @since 1.16
+     * @since 1.17
      */
     @Parameter( property = "license.licenseMergesUrl" )
     String licenseMergesUrl;


### PR DESCRIPTION
https://github.com/mojohaus/license-maven-plugin/issues/143 is not yet released. So the `@since` annotation is wrong.