### PR TITLE
Enhance overrideFile with overrideUrl - Closes #143

### DIFF
--- a/src/it/ISSUE-59/pom.xml
+++ b/src/it/ISSUE-59/pom.xml
@@ -49,6 +49,7 @@
     <license.deployMissingFile>true</license.deployMissingFile>
     <license.useRepositoryMissingFiles>true</license.useRepositoryMissingFiles>
     <license.failIfWarning>true</license.failIfWarning>
+    <license.overrideUrl>file://${basedir}/src/license/override-THIRD-PARTY.properties</license.overrideUrl>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -249,8 +249,18 @@ public abstract class AbstractAddThirdPartyMojo
      *
      * @since 1.12
      */
-    @Parameter( property = "license.overrideFile", defaultValue = "src/license/override-THIRD-PARTY.properties" )
+    @Deprecated
+    @Parameter( property = "license.overrideFile" )
     File overrideFile;
+
+    /**
+     * Location of file with license information for dependencies to override.
+     * <b>Note:</b> This option overrides {@link #overrideFile}.
+     *
+     * @since 1.17
+     */
+    @Parameter( property = "license.overrideUrl" )
+    String overrideUrl;
 
     /**
      * To merge licenses in final file.
@@ -748,6 +758,10 @@ public abstract class AbstractAddThirdPartyMojo
         return overrideFile;
     }
 
+    public String getOverrideUrl() {
+        return overrideUrl;
+    }
+
     String getLicenseMergesFile()
     {
         return licenseMergesFile;
@@ -1017,7 +1031,7 @@ public abstract class AbstractAddThirdPartyMojo
     void overrideLicenses() throws IOException
     {
         LicenseMap licenseMap1 = getLicenseMap();
-        thirdPartyTool.overrideLicenses( licenseMap1, projectDependencies, getEncoding(), overrideFile );
+        thirdPartyTool.overrideLicenses( licenseMap1, projectDependencies, getEncoding(), overrideFile, overrideUrl );
     }
 
     private boolean isFailOnMissing() {

--- a/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
@@ -188,8 +188,18 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport i
      *
      * @since 1.11
      */
-    @Parameter( property = "license.overrideFile", defaultValue = "src/license/override-THIRD-PARTY.properties" )
+    @Deprecated
+    @Parameter( property = "license.overrideFile" )
     private File overrideFile;
+
+    /**
+     * Location of file with license information for dependencies to override.
+     * <b>Note:</b> This option overrides {@link #overrideFile}.
+     *
+     * @since 1.17
+     */
+    @Parameter( property = "license.overrideUrl" )
+    String overrideUrl;
 
     /**
      * Load from repositories third party missing files.
@@ -555,7 +565,7 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport i
         thirdPartyHelper.mergeLicenses( licenseMerges, licenseMap );
 
         // Add override licenses
-        thirdPartyTool.overrideLicenses( licenseMap, projectDependencies, encoding, overrideFile );
+        thirdPartyTool.overrideLicenses( licenseMap, projectDependencies, encoding, overrideFile, overrideUrl );
 
         // let's build third party details for each dependencies
         Collection<ThirdPartyDetails> details = new ArrayList<>();

--- a/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
@@ -439,7 +439,7 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
         String absolutePath = mojo.getProject().getBasedir().getAbsolutePath();
 
         missingFile = new File(project.getBasedir(),mojo.missingFile.getAbsolutePath().substring(absolutePath.length()));
-        overrideFile  = new File(project.getBasedir(),mojo.overrideFile.getAbsolutePath().substring(absolutePath.length()));
+        overrideFile  = mojo.overrideFile == null ? null : new File(project.getBasedir(),mojo.overrideFile.getAbsolutePath().substring(absolutePath.length()));
         missingLicensesFileArtifact = mojo.missingLicensesFileArtifact;
         localRepository = mojo.localRepository;
         remoteRepositories = mojo.remoteRepositories;

--- a/src/main/java/org/codehaus/mojo/license/api/ThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/ThirdPartyTool.java
@@ -155,9 +155,10 @@ public interface ThirdPartyTool
      * @param artifactCache cache of dependencies (used for id migration from missing file)
      * @param encoding      encoding used to load override file
      * @param overrideFile  location of the optional override file
+     * @param overrideUrl   location of an optional override file extension that can be downloaded from some resource hoster
      * @throws IOException if pb while reading override file
      */
-    void overrideLicenses( LicenseMap licenseMap, SortedMap<String, MavenProject> artifactCache, String encoding, File overrideFile ) throws IOException;
+    void overrideLicenses( LicenseMap licenseMap, SortedMap<String, MavenProject> artifactCache, String encoding, File overrideFile, String overrideUrl ) throws IOException;
 
     /**
      * Add one or more licenses (name and url are {@code licenseNames}) to the given {@code licenseMap} for the given

--- a/src/site/apt/examples/example-thirdparty.apt.vm
+++ b/src/site/apt/examples/example-thirdparty.apt.vm
@@ -351,15 +351,13 @@ List of 2 third-party dependencies.
 
 ** Override identified licenses (Since 1.12)
 
-  Sometimes, identified licenses are wrong, using the <<overrideFile>> permits to fix them.
+  Sometimes, identified licenses are wrong, using the <<overrideUrl>> permits to fix them.
 
   For each dependency you want to fix, just add in this properties file a line
 
 -------------------------------------------------------------------------------
 org.jboss.xnio--xnio-api--3.3.6.Final=The Apache Software License, Version 2.0
 -------------------------------------------------------------------------------
-
-  The default location of the override file is <<src/main/license/override-THIRD-PARTY.properties>>.
 
 ** Attach missing files to build
 


### PR DESCRIPTION
This is basically 545ba8a8033666829763be77e305461e77a47180 (which was
for licenseMergesFile -> licenseMergesUrl) applied to overrideFile ->
overrideUrl.

The downside is that we can not support a default value for overrideFile
anymore. So users upgrading should explicitly set the overrideUrl
configuration property.