### PR TITLE
Extends documentation for include/exclude scopes

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -116,6 +116,9 @@ public abstract class AbstractAddThirdPartyMojo
 
     /**
      * A filter to exclude some scopes.
+     * <p>
+     * Multiple scopes are delimited by comma, eg. {@code <excludedScopes>test,provided</excludedScopes>}
+     * or {@code -Dlicense.excludedScopes="test,provided"}.
      *
      * @since 1.1
      */
@@ -124,6 +127,9 @@ public abstract class AbstractAddThirdPartyMojo
 
     /**
      * A filter to include only some scopes, if let empty then all scopes will be used (no filter).
+     * <p>
+     * Multiple scopes are delimited by comma, eg. {@code <includedScopes>test,provided</includedScopes>}
+     * or {@code -Dlicense.includedScopes="test,provided"}.
      *
      * @since 1.1
      */


### PR DESCRIPTION
The problem was that the property names are in plural (speaking from
included/ecluded scopes). So as a user I assume that I can add multiple
scopes, but nowhere in the documentation the syntax for that is mentioned.

After digging through the source code I found that the scopes are delimitted
by comma.

So I extend the documentation for the properties

- license.excludedScopes
- license.includedScopes

how to add multiple scopes.