### PR TITLE
161: Allow specifying missing licenses in the configuration of the pl…

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
@@ -118,6 +118,42 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
         return rejectPackaging( "pom" );
     }
 
+    @Override
+    void checkUnsafeDependencies() {
+        super.checkUnsafeDependencies();
+
+        try
+        {
+            // compute if missing file should be (re)-generate
+            doGenerateMissing = computeDoGenerateMissingFile(unsafeMappings, unsafeDependencies);
+        }
+        catch (IOException ioex)
+        {
+            getLog().error(ioex);
+        }
+        if ( doGenerateMissing && isVerbose() )
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.append( "Will use from missing file " );
+            sb.append( unsafeMappings.size() );
+            sb.append( " dependencies :" );
+            for ( Map.Entry<Object, Object> entry : unsafeMappings.entrySet() )
+            {
+                String id = (String) entry.getKey();
+                String license = (String) entry.getValue();
+                sb.append( "\n - " ).append( id ).append( " - " ).append( license );
+            }
+            getLog().info( sb.toString() );
+        }
+        else
+        {
+            if ( isUseMissingFile() && !unsafeMappings.isEmpty() )
+            {
+                getLog().info( "Missing file " + getMissingFile() + " is up-to-date." );
+            }
+        }
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -214,30 +250,6 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
             getLog().info( "found " + unsafeMappings.size() + " unsafe mappings" );
         }
 
-        // compute if missing file should be (re)-generate
-        doGenerateMissing = computeDoGenerateMissingFile( unsafeMappings, unsafeDependencies );
-
-        if ( doGenerateMissing && isVerbose() )
-        {
-            StringBuilder sb = new StringBuilder();
-            sb.append( "Will use from missing file " );
-            sb.append( unsafeMappings.size() );
-            sb.append( " dependencies :" );
-            for ( Map.Entry<Object, Object> entry : unsafeMappings.entrySet() )
-            {
-                String id = (String) entry.getKey();
-                String license = (String) entry.getValue();
-                sb.append( "\n - " ).append( id ).append( " - " ).append( license );
-            }
-            getLog().info( sb.toString() );
-        }
-        else
-        {
-            if ( isUseMissingFile() && !unsafeMappings.isEmpty() )
-            {
-                getLog().info( "Missing file " + getMissingFile() + " is up-to-date." );
-            }
-        }
         return unsafeMappings;
     }
 


### PR DESCRIPTION
…ugin

 - use the globalKnownLicenses property to allow customers to declare known licenses.
 - resolveUnsafeDependenciesFromFile method incorrectly checks if missingLicenses file exists and only then reads missingFileUrl property. To fix this we extract the logic in a new method called resolveUnsafeDependencies and in there we resolve dependencies 1) from the dependencies provided in the plugin configuration (globalKnownLicenses) 2) if missingLicenses file is present then we use the content of the file 3) missingFileUrl if the property is actually a url.
 - the doGenerateMissing logic was wrong as the field was initialized before the consolidate method, which is the one that actually resolves the unsafe dependencies. That's why the logic of the doGenerateMissing is now after the consolidate method.

See #161 