### PR TITLE
Issue 164: Fix dependency map sorting by name in add-third-party goal

### DIFF
--- a/src/it/add-third-party-with-deps-name-order/README.txt
+++ b/src/it/add-third-party-with-deps-name-order/README.txt
@@ -1,0 +1,3 @@
+To fix the ISSUE-164 bug (see https://github.com/mojohaus/license-maven-plugin/issues/164).
+
+Demonstrates that add-third-party goal sorts the third party file items by artifact name if enabled.

--- a/src/it/add-third-party-with-deps-name-order/invoker.properties
+++ b/src/it/add-third-party-with-deps-name-order/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean license:add-third-party
+invoker.failureBehavior=fail-fast

--- a/src/it/add-third-party-with-deps-name-order/pom.xml
+++ b/src/it/add-third-party-with-deps-name-order/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>add-third-party-with-deps-name-order</artifactId>
+  <version>@pom.version@</version>
+
+  <name>License Test :: add-third-party-with-deps-name-order</name>
+
+  <properties>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <license.thirdPartyFilename>third.txt</license.thirdPartyFilename>
+    <license.bundleThirdPartyPath>test/third.txt</license.bundleThirdPartyPath>
+    <license.generateBundle>true</license.generateBundle>
+    <license.verbose>true</license.verbose>
+    <license.sortArtifactByName>true</license.sortArtifactByName>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.8.1</version>
+    </dependency>
+  </dependencies>
+  <build>
+
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>
+
+

--- a/src/it/add-third-party-with-deps-name-order/postbuild.groovy
+++ b/src/it/add-third-party-with-deps-name-order/postbuild.groovy
@@ -1,0 +1,38 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+commonsLang = '(Apache License, Version 2.0) Apache Commons Lang (org.apache.commons:commons-lang3:3.8.1 - http://commons.apache.org/proper/commons-lang/)'
+commonsLogging = '(The Apache Software License, Version 2.0) Commons Logging (commons-logging:commons-logging:1.1.1 - http://commons.apache.org/logging)'
+
+file = new File(basedir, 'target/generated-sources/license/third.txt');
+assert file.exists();
+content = file.text;
+assert content.contains(commonsLang);
+assert content.indexOf(commonsLang) < content.indexOf(commonsLogging);
+
+file = new File(basedir, 'target/generated-sources/license/test/third.txt');
+assert file.exists();
+content = file.text;
+assert content.contains(commonsLang);
+assert content.indexOf(commonsLang) < content.indexOf(commonsLogging);
+
+return true;

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -683,15 +683,15 @@ public class DefaultThirdPartyTool
 
     private static Set<Map.Entry<MavenProject, String[]>> toSortedDependencyMapIfMarked( LicenseMap licenseMap )
     {
-        
+
         Set<Map.Entry<MavenProject, String[]>> entrySet = licenseMap.toDependencyMap().entrySet();
-        
+
         if ( licenseMap.isSortedByName() )
         {
             Comparator<Map.Entry<MavenProject, ?>> comparator = MojoHelper.newMavenProjectEntryComparatorByName();
             Set<Map.Entry<MavenProject, String[]>> sorted = new TreeSet<>( comparator );
             sorted.addAll( entrySet );
-            
+
             return sorted;
         }
         else

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -668,7 +668,7 @@ public class DefaultThirdPartyTool
 
         Map<String, Object> properties = new HashMap<>();
         properties.put( "licenseMap", licenseMap.entrySet() );
-        properties.put( "dependencyMap", licenseMap.toDependencyMap().entrySet() );
+        properties.put( "dependencyMap", toSortedDependencyMapIfMarked( licenseMap ) );
         String content = freeMarkerHelper.renderTemplate( lineFormat, properties );
 
         log.info( "Writing third-party file to " + thirdPartyFile );
@@ -679,6 +679,25 @@ public class DefaultThirdPartyTool
 
         FileUtil.printString( thirdPartyFile, content, encoding );
 
+    }
+
+    private static Set<Map.Entry<MavenProject, String[]>> toSortedDependencyMapIfMarked( LicenseMap licenseMap )
+    {
+        
+        Set<Map.Entry<MavenProject, String[]>> entrySet = licenseMap.toDependencyMap().entrySet();
+        
+        if ( licenseMap.isSortedByName() )
+        {
+            Comparator<Map.Entry<MavenProject, ?>> comparator = MojoHelper.newMavenProjectEntryComparatorByName();
+            Set<Map.Entry<MavenProject, String[]>> sorted = new TreeSet<>( comparator );
+            sorted.addAll( entrySet );
+            
+            return sorted;
+        }
+        else
+        {
+            return entrySet;
+        }
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/license/model/LicenseMap.java
+++ b/src/main/java/org/codehaus/mojo/license/model/LicenseMap.java
@@ -65,7 +65,7 @@ public class LicenseMap
 
     /**
      * Defines whether this license map was marked as sorted by name.
-     * 
+     *
      * @return flag
      */
     public boolean isSortedByName()

--- a/src/main/java/org/codehaus/mojo/license/model/LicenseMap.java
+++ b/src/main/java/org/codehaus/mojo/license/model/LicenseMap.java
@@ -22,7 +22,6 @@ package org.codehaus.mojo.license.model;
  * #L%
  */
 
-import java.util.Collection;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.mojo.license.utils.MojoHelper;
 
@@ -54,12 +53,24 @@ public class LicenseMap
 
     private final Comparator<MavenProject> projectComparator;
 
+    private boolean sortedByName = false;
+
     /**
      * Default contructor.
      */
     public LicenseMap()
     {
         projectComparator = MojoHelper.newMavenProjectComparator();
+    }
+
+    /**
+     * Defines whether this license map was marked as sorted by name.
+     * 
+     * @return flag
+     */
+    public boolean isSortedByName()
+    {
+        return sortedByName;
     }
 
     /**
@@ -149,6 +160,7 @@ public class LicenseMap
     public LicenseMap toLicenseMapOrderByName()
     {
         LicenseMap result = new LicenseMap();
+        result.sortedByName = true;
 
         Comparator<MavenProject> mavenProjectComparator = MojoHelper.newMavenProjectComparatorByName();
         for ( Map.Entry<String, SortedSet<MavenProject>> entry : entrySet() )

--- a/src/main/java/org/codehaus/mojo/license/utils/MojoHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/utils/MojoHelper.java
@@ -33,6 +33,7 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Mojo helper methods.
@@ -134,7 +135,25 @@ public class MojoHelper
 
                 String id1 = getProjectName( o1 );
                 String id2 = getProjectName( o2 );
-                return id1.compareTo( id2 );
+                return id1.compareToIgnoreCase( id2 );
+            }
+        };
+
+    }
+
+    public static Comparator<Map.Entry<MavenProject, ?>> newMavenProjectEntryComparatorByName()
+    {
+        return new Comparator<Map.Entry<MavenProject, ?>>()
+        {
+            /**
+             * {@inheritDoc}
+             */
+            public int compare( Map.Entry<MavenProject, ?> o1, Map.Entry<MavenProject, ?> o2 )
+            {
+
+                String id1 = getProjectName( o1.getKey() );
+                String id2 = getProjectName( o2.getKey() );
+                return id1.compareToIgnoreCase( id2 );
             }
         };
 


### PR DESCRIPTION
The fix is done by carrying information whether the License Map was sorted by name.
If so the Third Party Tool sorts the `dependencyMap`.

Additionally sorting is case insensitive which makes more sense for Maven project names.