### PR TITLE
Add the ability to transform a license url with a regular expression/replacement pair.

### DIFF
--- a/src/it/ISSUE-154/expected_licenses.xml
+++ b/src/it/ISSUE-154/expected_licenses.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<licenseSummary>
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.xnio</groupId>
+      <artifactId>xnio-api</artifactId>
+      <version>3.3.6.Final</version>
+      <licenses>
+        <license>
+          <name>Public Domain</name>
+          <url>http://repository.jboss.org/licenses/cc0-1.0.txt</url>
+          <distribution>repo</distribution>
+          <file>public domain - cc0-1.0.txt</file>
+        </license>
+      </licenses>
+    </dependency>
+  </dependencies>
+</licenseSummary>

--- a/src/it/ISSUE-154/invoker.properties
+++ b/src/it/ISSUE-154/invoker.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+#
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean license:download-licenses
+invoker.failureBehavior=fail-fast

--- a/src/it/ISSUE-154/pom.xml
+++ b/src/it/ISSUE-154/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>test-ISSUE-154</artifactId>
+  <version>@pom.version@</version>
+
+  <name>License Test :: ISSUE-154</name>
+  <packaging>jar</packaging>
+
+  <licenses>
+    <license>
+      <name>The GNU Lesser General Public License, Version 3.0</name>
+      <url>http://www.gnu.org/licenses/lgpl-3.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <license.verbose>true</license.verbose>
+    <license.sortByGroupIdAndArtifactId>true</license.sortByGroupIdAndArtifactId>
+    <licensesOutputFile>${project.build.directory}/licenses.xml</licensesOutputFile>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.xnio</groupId>
+      <artifactId>xnio-api</artifactId>
+      <version>3.3.6.Final</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+          <configuration>
+            <licenseUrlReplacements>
+              <licenseUrlReplacement>
+                <regexp>^.*$</regexp>
+                <replacement>file://${project.basedir}/src/alternative.txt</replacement>
+              </licenseUrlReplacement>
+            </licenseUrlReplacements>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>
+

--- a/src/it/ISSUE-154/postbuild.groovy
+++ b/src/it/ISSUE-154/postbuild.groovy
@@ -1,0 +1,29 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+file = new File(basedir, 'target/licenses.xml');
+expectedFile = new File(basedir, 'expected_licenses.xml');
+assert expectedFile.text.equals(file.text);
+
+licenseFile = new File(basedir, 'target/generated-resources/licenses/public domain - cc0-1.0.txt');
+expectedLicenseTxt = new File(basedir, 'src/alternative.txt');
+assert expectedLicenseTxt.text.equals(licenseFile.text);

--- a/src/it/ISSUE-154/src/alternative.txt
+++ b/src/it/ISSUE-154/src/alternative.txt
@@ -1,0 +1,1 @@
+alternative

--- a/src/main/java/org/codehaus/mojo/license/LicenseUrlReplacement.java
+++ b/src/main/java/org/codehaus/mojo/license/LicenseUrlReplacement.java
@@ -1,0 +1,67 @@
+package org.codehaus.mojo.license;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2018 Codehaus
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.regex.Pattern;
+
+/**
+ * Defines a license url pattern and replacement pair.
+ *
+ * @since 1.17
+ */
+public class LicenseUrlReplacement
+{
+    /**
+     * Regular expression used to identify license urls that are to be replaced.
+     *
+     * @since 1.17
+     */
+    private Pattern regexp;
+
+    /**
+     * Replacement license url.
+     *
+     * <p>Be aware that the replacement is passed to {@link java.util.regex.Matcher#replaceAll(String)
+     * java.util.regex.Matcher#replaceAll(String)}, so be aware of the significance of backslashes (<tt>\</tt>)
+     * and dollar signs (<tt>$</tt>) within the replacement string.
+     *
+     * @since 1.17
+     */
+    private String replacement;
+
+    Pattern getRegexp()
+    {
+        return regexp;
+    }
+
+    @SuppressWarnings( "unused" )
+    public void setRegexp( final String regexp )
+    {
+        this.regexp = Pattern.compile( regexp );
+    }
+
+    String getReplacement()
+    {
+        return replacement;
+    }
+}


### PR DESCRIPTION
Allows a project to, say, workaround a project's duff or stale license metadata.

Fixes #154