### PR TITLE
Fix #192 Dependency map sorting by project name with ignored case in add-third-party goal

### DIFF
--- a/src/it/add-third-party-with-deps-name-order/pom.xml
+++ b/src/it/add-third-party-with-deps-name-order/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.8.1</version>
     </dependency>
+    <dependency>
+      <groupId>antlr</groupId>
+      <artifactId>antlr</artifactId>
+      <version>2.7.1</version>
+    </dependency>
   </dependencies>
   <build>
 

--- a/src/it/add-third-party-with-deps-name-order/postbuild.groovy
+++ b/src/it/add-third-party-with-deps-name-order/postbuild.groovy
@@ -20,17 +20,20 @@
  * #L%
  */
 
+antlr = '(Unknown license) antlr (antlr:antlr:2.7.1 - no url defined)'
 commonsLang = '(Apache License, Version 2.0) Apache Commons Lang (org.apache.commons:commons-lang3:3.8.1 - http://commons.apache.org/proper/commons-lang/)'
 commonsLogging = '(The Apache Software License, Version 2.0) Commons Logging (commons-logging:commons-logging:1.1.1 - http://commons.apache.org/logging)'
 
 file = new File(basedir, 'target/generated-sources/license/third.txt');
 assert file.exists();
 content = file.text;
-assert content.contains(commonsLang);
+assert content.contains(antlr);
+assert content.indexOf(antlr) < content.indexOf(commonsLogging);
 assert content.indexOf(commonsLang) < content.indexOf(commonsLogging);
 
 file = new File(basedir, 'target/generated-sources/license/test/third.txt');
 assert file.exists();
 content = file.text;
-assert content.contains(commonsLang);
+assert content.contains(antlr);
+assert content.indexOf(antlr) < content.indexOf(commonsLogging);
 assert content.indexOf(commonsLang) < content.indexOf(commonsLogging);

--- a/src/main/java/org/codehaus/mojo/license/utils/MojoHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/utils/MojoHelper.java
@@ -134,7 +134,7 @@ public class MojoHelper
 
                 String id1 = getProjectName( o1 );
                 String id2 = getProjectName( o2 );
-                return id1.compareTo( id2 );
+                return id1.compareToIgnoreCase( id2 );
             }
         };
 


### PR DESCRIPTION
Currently the **add-third-party** performs ordering of dependencies using **String#compareTo**. This causes that e.g. _antlr_ dependency is added to the third party file after _Apache Commons Lang_ dependency. This merge request change this behavior and performs ordering with ignored case.

Integration test add-third-party-with-deps-name-order was extended for dependency ignore case order check.