### PR TITLE
Fix #204 : change licenseMergesUrl to make build portable 

### DIFF
--- a/src/it/MLICENSE-132/pom.xml
+++ b/src/it/MLICENSE-132/pom.xml
@@ -42,7 +42,7 @@
           <artifactId>license-maven-plugin</artifactId>
           <version>@pom.version@</version>
           <configuration>
-            <licenseMergesUrl>file://${project.basedir}/licenses.merge</licenseMergesUrl>
+            <licenseMergesUrl>${project.baseUri}licenses.merge</licenseMergesUrl>
             <useMissingFile>true</useMissingFile>
             <includeTransitiveDependencies>false</includeTransitiveDependencies>
             <licenseMerges>


### PR DESCRIPTION
Fix issue #204:  integration test for MLICENSE-132  failed on Windows because an invalid licenseMergesUrl