### PR TITLE
Fix #208 : change replacement url to make build portable

### DIFF
--- a/src/it/ISSUE-154/pom.xml
+++ b/src/it/ISSUE-154/pom.xml
@@ -68,7 +68,7 @@
             <licenseUrlReplacements>
               <licenseUrlReplacement>
                 <regexp>^.*$</regexp>
-                <replacement>file://${project.basedir}/src/alternative.txt</replacement>
+                <replacement>${project.baseUri}src/alternative.txt</replacement>
               </licenseUrlReplacement>
             </licenseUrlReplacements>
           </configuration>


### PR DESCRIPTION
fix windows build