### PR TITLE
Fix #195 Handle license names with slashes when in organizeLicensesByDependencies mode

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -37,6 +37,7 @@ import org.codehaus.mojo.license.model.ProjectLicense;
 import org.codehaus.mojo.license.model.ProjectLicenseInfo;
 import org.codehaus.mojo.license.utils.FileUtil;
 import org.codehaus.mojo.license.utils.LicenseDownloader;
+import org.codehaus.mojo.license.utils.LicenseNotFoundException;
 import org.codehaus.mojo.license.utils.LicenseSummaryReader;
 import org.codehaus.mojo.license.utils.LicenseSummaryWriter;
 import org.codehaus.mojo.license.utils.MojoHelper;
@@ -44,7 +45,6 @@ import org.codehaus.plexus.util.Base64;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -737,7 +737,7 @@ public abstract class AbstractDownloadLicensesMojo
             licenseFileName = String.format( "%s.%s%s", depProject.getGroupId(), depProject.getArtifactId(),
                                              licenseName != null
                                                  ? "_" + licenseName
-                                                 : "" ).toLowerCase().replaceAll( "\\s+", "_" );
+                                                 : "" ).toLowerCase().replaceAll( "[/\\s]+", "_" );
         }
         else
         {
@@ -830,12 +830,12 @@ public abstract class AbstractDownloadLicensesMojo
                                        + licenseUrl );
                 }
             }
-            catch ( FileNotFoundException e )
+            catch ( LicenseNotFoundException e )
             {
                 if ( !quiet )
                 {
                     getLog().warn( "POM for dependency " + depProject.toString()
-                                       + " has a license URL that returns file not found: " + licenseUrl );
+                                       + " has a license URL that returns file not found: " + e.getLicenseUrl() );
                 }
             }
             catch ( IOException e )

--- a/src/main/java/org/codehaus/mojo/license/utils/LicenseDownloader.java
+++ b/src/main/java/org/codehaus/mojo/license/utils/LicenseDownloader.java
@@ -23,6 +23,7 @@ package org.codehaus.mojo.license.utils;
  */
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -86,7 +87,7 @@ public class LicenseDownloader
 
         }
 
-        try ( InputStream licenseInputStream = connection.getInputStream() )
+        try ( InputStream licenseInputStream = getConnectionInputStream( connection ) )
         {
             File updatedFile = updateFileExtension( outputFile, connection.getContentType() );
             try ( FileOutputStream fos = new FileOutputStream( updatedFile ) )
@@ -146,6 +147,18 @@ public class LicenseDownloader
             }
         }
         return outputFile;
+    }
+
+    private static InputStream getConnectionInputStream( final URLConnection connection ) throws IOException
+    {
+        try
+        {
+            return connection.getInputStream();
+        }
+        catch ( FileNotFoundException e )
+        {
+            throw new LicenseNotFoundException( connection.getURL(), e );
+        }
     }
 
     private static String getFileExtension( String mimeType )

--- a/src/main/java/org/codehaus/mojo/license/utils/LicenseNotFoundException.java
+++ b/src/main/java/org/codehaus/mojo/license/utils/LicenseNotFoundException.java
@@ -1,0 +1,48 @@
+package org.codehaus.mojo.license.utils;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2018 Codehaus
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Exception to be thrown when a license url returns not found.
+ */
+public class LicenseNotFoundException extends IOException
+{
+    private static final long serialVersionUID = 1L;
+
+    private final URL licenseUrl;
+
+    LicenseNotFoundException( final URL licenseUrl, final FileNotFoundException e )
+    {
+        super( e );
+        this.licenseUrl = licenseUrl;
+    }
+
+    public URL getLicenseUrl()
+    {
+        return licenseUrl;
+    }
+}


### PR DESCRIPTION
Also refactored LicenseDownloader exception handling to separate a local file not found condition from a remote one.