### PR TITLE
Fix #245 add missingFileUrl in initFromMojo method

### DIFF
--- a/src/it/aggregate-add-third-party-missing-file/child1/pom.xml
+++ b/src/it/aggregate-add-third-party-missing-file/child1/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2019 - Nikolas Falco
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>aggregate-add-third-party-missing-file</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <artifactId>test-aggregate-add-third-party-child1</artifactId>
+
+  <name>License Test :: aggregate-add-third-party-missing-file - child 1</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.jettison</groupId>
+      <artifactId>jettison</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20070829</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/aggregate-add-third-party-missing-file/invoker.properties
+++ b/src/it/aggregate-add-third-party-missing-file/invoker.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2019 - Nikolas Falco
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+#
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean license:aggregate-add-third-party
+invoker.failureBehavior=fail-never

--- a/src/it/aggregate-add-third-party-missing-file/pom.xml
+++ b/src/it/aggregate-add-third-party-missing-file/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2019 - Nikolas Falco
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>aggregate-add-third-party-missing-file</artifactId>
+  <version>@pom.version@</version>
+
+  <modules>
+    <module>child1</module>
+  </modules>
+
+  <name>License Test :: aggregate-add-third-party-missing-file</name>
+
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <license.verbose>true</license.verbose>
+    <license.useMissingFile>true</license.useMissingFile>
+    <license.missingFileUrl>http://this.url.does.not.exists/THIRD-PARTY.properties</license.missingFileUrl>
+  </properties>
+
+  <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/src/it/aggregate-add-third-party-missing-file/postbuild.groovy
+++ b/src/it/aggregate-add-third-party-missing-file/postbuild.groovy
@@ -1,0 +1,29 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2019 - Falco Nikolas
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+
+file = new File(basedir, 'build.log');
+assert file.exists();
+content = file.text;
+
+// verify that missingFileUrl taken into account
+assert content.contains('Unknown host this.url.does.not.exists') || content.contains('No such host is known (this.url.does.not.exists)');

--- a/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
@@ -490,6 +490,7 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
 
         missingFile = new File( project.getBasedir(),
                 mojo.missingFile.getAbsolutePath().substring( absolutePath.length() ) );
+        missingFileUrl = mojo.missingFileUrl;
         resolvedOverrideUrl  = mojo.resolvedOverrideUrl;
         missingLicensesFileArtifact = mojo.missingLicensesFileArtifact;
         localRepository = mojo.localRepository;


### PR DESCRIPTION
Add missingFileUrl in AddThirdPartyMojo initFromMojo method when copy attributes from caller mojo AggregatorAddThirdPartyMojo.

I had also change the signature from AggregatorAddThirdPartyMojo to AbstractAddThirdPartyMojo to remove the cyclic dependency.