### PR TITLE
Fix #258 aggregate-third-party-report goal fails when licenseMerges

### DIFF
--- a/src/it/aggregate-third-party-report-merge-licences/child1/pom.xml
+++ b/src/it/aggregate-third-party-report-merge-licences/child1/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-aggregate-third-party-report-merge-licenses</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <artifactId>test-aggregate-third-party-report-child1</artifactId>
+
+  <name>License Test :: aggregate-third-party-report - child 1</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+  </dependencies>
+
+</project>
+
+

--- a/src/it/aggregate-third-party-report-merge-licences/child2/pom.xml
+++ b/src/it/aggregate-third-party-report-merge-licences/child2/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-aggregate-third-party-report-merge-licenses</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <artifactId>test-aggregate-third-party-report-merge-licenses-child2</artifactId>
+
+  <name>License Test :: aggregate-third-party-report-merge-licenses - child 2</name>
+
+  <dependencies>
+
+    <!-- use license 'Apache License, Version 2.0' -->
+    <dependency>
+      <groupId>com.jhlabs</groupId>
+      <artifactId>filters</artifactId>
+      <version>2.0.235</version>
+    </dependency>
+
+    <!-- use license 'Apache Public License 2.0' -->
+    <dependency>
+      <groupId>org.sonatype.plexus</groupId>
+      <artifactId>plexus-cipher</artifactId>
+      <version>1.4</version>
+    </dependency>
+  </dependencies>
+
+</project>
+
+

--- a/src/it/aggregate-third-party-report-merge-licences/invoker.properties
+++ b/src/it/aggregate-third-party-report-merge-licences/invoker.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+#
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean license:aggregate-third-party-report
+invoker.failureBehavior=fail-fast

--- a/src/it/aggregate-third-party-report-merge-licences/pom.xml
+++ b/src/it/aggregate-third-party-report-merge-licences/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>test-aggregate-third-party-report-merge-licenses</artifactId>
+  <version>@pom.version@</version>
+
+  <modules>
+    <module>child1</module>
+    <module>child2</module>
+  </modules>
+
+  <name>License Test :: aggregate-third-party-report-merge-licenses</name>
+
+  <packaging>pom</packaging>
+
+  <properties>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <license.generateBundle>true</license.generateBundle>
+    <license.verbose>true</license.verbose>
+  </properties>
+
+  <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+          <configuration>
+            <licenseMerges>
+              <licenseMerge>The Apache Software License, Version 2.0|Apache License, Version 2.0|Apache Public License 2.0</licenseMerge>
+            </licenseMerges>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>
+
+

--- a/src/it/aggregate-third-party-report-merge-licences/postbuild.groovy
+++ b/src/it/aggregate-third-party-report-merge-licences/postbuild.groovy
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+file = new File(basedir, 'target/site/aggregate-third-party-report.html');
+assert file.exists();
+content = file.text;
+assert !content.contains('the project has no dependencies.');
+assert !content.contains('/third-party-report.html#');
+assert content.contains('<a href="#commons-logging:commons-logging:1.1.1">commons-logging:commons-logging:1.1.1</a>');
+assert content.contains('<a href="#com.jhlabs:filters:2.0.235">com.jhlabs:filters:2.0.235</a>');
+assert content.contains('<a href="#org.sonatype.plexus:plexus-cipher:1.4">org.sonatype.plexus:plexus-cipher:1.4</a>');
+assert content.contains('<td>The Apache Software License, Version 2.0</td>');
+assert !content.contains('<td>Apache License, Version 2.0</td>');
+assert !content.contains('<td>Apache Public License 2.0</td>');

--- a/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
@@ -552,7 +552,8 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport
         ResolvedProjectDependencies loadedDependencies;
         if ( loadArtifacts )
         {
-            loadedDependencies = dependenciesTool.loadProjectArtifacts( localRepository, licenseMerges, project, null );
+            loadedDependencies = dependenciesTool.loadProjectArtifacts( localRepository,
+                    project.getRemoteArtifactRepositories(), project, null );
         }
         else
         {


### PR DESCRIPTION
As request this is an integration test for aggregate-third-party-report with a configured licenseMerges.
The build fails with 

> [ERROR] Failed to execute goal org.codehaus.mojo:license-maven-plugin:1.18-SNAPSHOT:aggregate-third-party-report (default-cli) on project test-aggregate-third-party-report-merge-licenses: A type incompatibility occurred while executing org.codehaus.mojo:license-maven-plugin:1.18-SNAPSHOT:aggregate-third-party-report: java.lang.String cannot be cast to org.apache.maven.artifact.repository.ArtifactRepository

My colleague @elballa will provide a fix for this