### PR TITLE
Fix #134 when missingFileUrl contains more lines

### DIFF
--- a/src/it/add-third-party-missing-file/missing-licenses.properties
+++ b/src/it/add-third-party-missing-file/missing-licenses.properties
@@ -1,1 +1,2 @@
 org.json--json--20070829=The JSON License by file url
+javax.resource--connector-api--1.5=CDDL + GPLv2 with classpath exception by file url

--- a/src/it/add-third-party-missing-file/pom.xml
+++ b/src/it/add-third-party-missing-file/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>json</artifactId>
       <version>20070829</version>
     </dependency>
+    <dependency>
+      <groupId>javax.resource</groupId>
+      <artifactId>connector-api</artifactId>
+      <version>1.5</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/it/add-third-party-missing-file/postbuild.groovy
+++ b/src/it/add-third-party-missing-file/postbuild.groovy
@@ -24,8 +24,10 @@ file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY-by-classp
 assert file.exists();
 content = file.text;
 assert content.contains('The JSON License by classpath url');
+assert content.contains('CDDL + GPLv2 with classpath exception by classpath url');
 
 file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY-by-file.txt');
 assert file.exists();
 content = file.text;
 assert content.contains('The JSON License by file url');
+assert content.contains('CDDL + GPLv2 with classpath exception by file url');

--- a/src/it/add-third-party-missing-file/prebuild.groovy
+++ b/src/it/add-third-party-missing-file/prebuild.groovy
@@ -27,10 +27,12 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
-JarOutputStream licenseRepo = new JarOutputStream(new FileOutputStream(new File(basedir, "license-repo.jar")));
+String missingLicences = "org.json--json--20070829=The JSON License by classpath url\n" +
+                         "javax.resource--connector-api--1.5=CDDL + GPLv2 with classpath exception by classpath url";
 
+JarOutputStream licenseRepo = new JarOutputStream(new FileOutputStream(new File(basedir, "license-repo.jar")));
 licenseRepo.putNextEntry(new ZipEntry("missing-licenses.properties"));
-licenseRepo.write("org.json--json--20070829=The JSON License by classpath url".getBytes("UTF-8"));
+licenseRepo.write(missingLicences.getBytes("UTF-8"));
 licenseRepo.closeEntry();
 
 licenseRepo.close();

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -695,7 +695,7 @@ public abstract class AbstractAddThirdPartyMojo
             getLog().warn( "" );
             if ( UrlRequester.isStringUrl( licenseMergesUrl ) )
             {
-                licenseMerges = Arrays.asList( UrlRequester.getFromUrl( licenseMergesUrl ) );
+                licenseMerges = Arrays.asList( UrlRequester.getFromUrl( licenseMergesUrl ).split( "\n" ) );
             }
         }
 


### PR DESCRIPTION
With latest PR I remove for mistake the `.split( "\n" )` from missingFileUrl than means now read only the first line of the content of URL.

I had update the integration test with one more missing license dependency so the file loaded by URL contains two lines.