### PR TITLE
Fix #271 aggregate-add-third-party evaluate acceptPomPackage also for current project

### DIFF
--- a/src/it/aggregate-add-third-party-no-children/invoker.properties
+++ b/src/it/aggregate-add-third-party-no-children/invoker.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2019, Falco Nikolas
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+#
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean license:aggregate-add-third-party@accept-pom license:aggregate-add-third-party@not-accept-pom
+invoker.failureBehavior=fail-fast

--- a/src/it/aggregate-add-third-party-no-children/pom.xml
+++ b/src/it/aggregate-add-third-party-no-children/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2019, Falco Nikolas
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>test-aggregate-add-third-party-no-children</artifactId>
+  <version>@pom.version@</version>
+  <packaging>pom</packaging>
+  <name>License Test :: aggregate-add-third-party-no-children</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <license.verbose>true</license.verbose>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.8.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>accept-pom</id>
+            <goals>
+              <goal>aggregate-add-third-party</goal>
+            </goals>
+            <configuration>
+              <acceptPomPackaging>true</acceptPomPackaging>
+              <thirdPartyFilename>THIRD-PARTY-accept-pom.txt</thirdPartyFilename>
+            </configuration>
+          </execution>
+          <execution>
+            <id>not-accept-pom</id>
+            <goals>
+              <goal>aggregate-add-third-party</goal>
+            </goals>
+            <configuration>
+              <thirdPartyFilename>THIRD-PARTY-not-accept-pom.txt</thirdPartyFilename>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/aggregate-add-third-party-no-children/postbuild.groovy
+++ b/src/it/aggregate-add-third-party-no-children/postbuild.groovy
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2019, Falco Nikolas
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY-accept-pom.txt');
+assert file.exists();
+content = file.text;
+assert !content.toLowerCase().contains('the project has no dependencies');
+assert content.contains('(The Apache Software License, Version 2.0) Commons Logging (commons-logging:commons-logging:1.1.1 - http://commons.apache.org/logging)');
+assert content.contains('(Apache License, Version 2.0) Apache Commons Lang (org.apache.commons:commons-lang3:3.8.1 - http://commons.apache.org/proper/commons-lang/)');
+
+file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY-not-accept-pom.txt');
+assert file.exists();
+content = file.text;
+assert content.toLowerCase().contains('the project has no dependencies');

--- a/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
@@ -210,9 +210,9 @@ public class AggregatorAddThirdPartyMojo extends AbstractAddThirdPartyMojo
 
         for ( MavenProject reactorProject : reactorProjects )
         {
-            if ( getProject().equals( reactorProject ) )
+            if ( getProject().equals( reactorProject ) && !acceptPomPackaging )
             {
-                // do not process pom
+                // does not process this pom unless specified
                 continue;
             }
 


### PR DESCRIPTION
The aggregate-add-third-party goal now evaluate acceptPomPackage also for the current project like add-third-party does.