### PR TITLE
Fix #277 aggregate-add-third-party does not use missingFileUrl parameter

### DIFF
--- a/src/it/aggregate-add-third-party-missing-file/child/pom.xml
+++ b/src/it/aggregate-add-third-party-missing-file/child/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2019 Alessandro Ballarin
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-aggregate-add-third-party-missing-file</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <artifactId>test-aggregate-add-third-party-child</artifactId>
+
+  <name>License Test :: aggregate-add-third-party - child</name>
+
+  <dependencies>
+
+    <!-- no license -->
+    <dependency>
+      <groupId>javax.resource</groupId>
+      <artifactId>connector-api</artifactId>
+      <version>1.5</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jettison</groupId>
+      <artifactId>jettison</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20070829</version>
+    </dependency>
+  </dependencies>
+
+</project>
+
+

--- a/src/it/aggregate-add-third-party-missing-file/invoker.properties
+++ b/src/it/aggregate-add-third-party-missing-file/invoker.properties
@@ -19,5 +19,5 @@
 # <http://www.gnu.org/licenses/lgpl-3.0.html>.
 # #L%
 ###
-invoker.goals=clean license:aggregate-add-third-party@missing-file-only
+invoker.goals=clean license:aggregate-add-third-party@missing-file-only license:aggregate-add-third-party@missing-file-url-only license:aggregate-add-third-party@missing-file-both
 invoker.failureBehavior=fail-fast

--- a/src/it/aggregate-add-third-party-missing-file/invoker.properties
+++ b/src/it/aggregate-add-third-party-missing-file/invoker.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2019 Alessandro Ballarin
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+#
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean license:aggregate-add-third-party@missing-file-only
+invoker.failureBehavior=fail-fast

--- a/src/it/aggregate-add-third-party-missing-file/missingFile.properties
+++ b/src/it/aggregate-add-third-party-missing-file/missingFile.properties
@@ -1,0 +1,3 @@
+javax.resource--connector-api--1.5=CDDL-1.0 - Common Development and Distribution License 1.0
+org.codehaus.jettison--jettison--1.1=Apache-2.0 - Apache License 2.0
+org.json--json--20070829=The JSON License

--- a/src/it/aggregate-add-third-party-missing-file/missingFileBoth.properties
+++ b/src/it/aggregate-add-third-party-missing-file/missingFileBoth.properties
@@ -1,0 +1,2 @@
+javax.resource--connector-api--1.5=CDDL-1.0 - Common Development and Distribution License 1.0
+org.codehaus.jettison--jettison--1.1=Apache-2.0 - Apache License 2.0

--- a/src/it/aggregate-add-third-party-missing-file/missingFileUrl.properties
+++ b/src/it/aggregate-add-third-party-missing-file/missingFileUrl.properties
@@ -1,0 +1,3 @@
+javax.resource--connector-api--1.5=CDDL-1.0 - Common Development and Distribution License 1.0
+org.codehaus.jettison--jettison--1.1=Apache-2.0 - Apache License 2.0
+org.json--json--20070829=The JSON License

--- a/src/it/aggregate-add-third-party-missing-file/missingFileUrlBoth.properties
+++ b/src/it/aggregate-add-third-party-missing-file/missingFileUrlBoth.properties
@@ -1,0 +1,1 @@
+org.json--json--20070829=The JSON License

--- a/src/it/aggregate-add-third-party-missing-file/pom.xml
+++ b/src/it/aggregate-add-third-party-missing-file/pom.xml
@@ -71,6 +71,21 @@
               <thirdPartyFilename>THIRD-PARTY-missing-file-only.txt</thirdPartyFilename>
             </configuration>
           </execution>
+          <execution>
+            <id>missing-file-url-only</id>
+            <configuration>
+              <missingFileUrl>${project.baseUri}missingFileUrl.properties</missingFileUrl>
+              <thirdPartyFilename>THIRD-PARTY-missing-file-url-only.txt</thirdPartyFilename>
+            </configuration>
+          </execution>
+          <execution>
+            <id>missing-file-both</id>
+            <configuration>
+              <missingFile>missingFileBoth.properties</missingFile>
+              <missingFileUrl>${project.baseUri}missingFileUrlBoth.properties</missingFileUrl>
+              <thirdPartyFilename>THIRD-PARTY-missing-file-both.txt</thirdPartyFilename>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/src/it/aggregate-add-third-party-missing-file/pom.xml
+++ b/src/it/aggregate-add-third-party-missing-file/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2019 Alessandro Ballarin
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>test-aggregate-add-third-party-missing-file</artifactId>
+  <version>@pom.version@</version>
+
+  <modules>
+    <module>child</module>
+  </modules>
+
+  <name>License Test :: aggregate-add-third-party-missing-file</name>
+
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+          <configuration>
+            <failOnMissing>true</failOnMissing>
+            <verbose>true</verbose>
+            <useMissingFile>true</useMissingFile>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>missing-file-only</id>
+            <configuration>
+              <missingFile>missingFile.properties</missingFile>
+              <thirdPartyFilename>THIRD-PARTY-missing-file-only.txt</thirdPartyFilename>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
+
+

--- a/src/it/aggregate-add-third-party-missing-file/postbuild.groovy
+++ b/src/it/aggregate-add-third-party-missing-file/postbuild.groovy
@@ -1,0 +1,29 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2019 Alessandro Ballarin
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+
+file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY-missing-file-only.txt');
+assert file.exists();
+content = file.text;
+assert content.contains('(CDDL-1.0 - Common Development and Distribution License 1.0) connector-api (javax.resource:connector-api:1.5 - no url defined)');
+assert content.contains('(Apache-2.0 - Apache License 2.0) Jettison (org.codehaus.jettison:jettison:1.1 - no url defined)');
+assert content.contains('(The JSON License) JSON (JavaScript Object Notation) (org.json:json:20070829 - http://www.json.org/java/index.html)');

--- a/src/it/aggregate-add-third-party-missing-file/postbuild.groovy
+++ b/src/it/aggregate-add-third-party-missing-file/postbuild.groovy
@@ -27,3 +27,17 @@ content = file.text;
 assert content.contains('(CDDL-1.0 - Common Development and Distribution License 1.0) connector-api (javax.resource:connector-api:1.5 - no url defined)');
 assert content.contains('(Apache-2.0 - Apache License 2.0) Jettison (org.codehaus.jettison:jettison:1.1 - no url defined)');
 assert content.contains('(The JSON License) JSON (JavaScript Object Notation) (org.json:json:20070829 - http://www.json.org/java/index.html)');
+
+file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY-missing-file-url-only.txt');
+assert file.exists();
+content = file.text;
+assert content.contains('(CDDL-1.0 - Common Development and Distribution License 1.0) connector-api (javax.resource:connector-api:1.5 - no url defined)');
+assert content.contains('(Apache-2.0 - Apache License 2.0) Jettison (org.codehaus.jettison:jettison:1.1 - no url defined)');
+assert content.contains('(The JSON License) JSON (JavaScript Object Notation) (org.json:json:20070829 - http://www.json.org/java/index.html)');
+
+file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY-missing-file-both.txt');
+assert file.exists();
+content = file.text;
+assert content.contains('(CDDL-1.0 - Common Development and Distribution License 1.0) connector-api (javax.resource:connector-api:1.5 - no url defined)');
+assert content.contains('(Apache-2.0 - Apache License 2.0) Jettison (org.codehaus.jettison:jettison:1.1 - no url defined)');
+assert content.contains('(The JSON License) JSON (JavaScript Object Notation) (org.json:json:20070829 - http://www.json.org/java/index.html)');

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -882,22 +882,27 @@ public abstract class AbstractAddThirdPartyMojo
 
     void resolveUnsafeDependenciesFromFile( File missingLicenses ) throws IOException, MojoExecutionException
     {
-        if ( missingLicenses != null && missingLicenses.exists() && missingLicenses.length() > 0 )
+        if ( missingLicenses == null )
         {
-            // there are missing licenses available from the artifact
-            SortedProperties unsafeMappings = new SortedProperties( getEncoding() );
+            return;
+        }
 
-            if ( missingLicenses.exists() )
-            {
-                // load the missing file
-                unsafeMappings.load( missingLicenses );
-            }
-            if ( UrlRequester.isStringUrl( missingFileUrl ) )
-            {
-                String httpRequestResult = UrlRequester.getFromUrl( missingFileUrl );
-                unsafeMappings.load( new ByteArrayInputStream( httpRequestResult.getBytes() ) );
-            }
+        // there are missing licenses available from the artifact
+        SortedProperties unsafeMappings = new SortedProperties( getEncoding() );
 
+        if ( missingLicenses.exists() && missingLicenses.length() > 0 )
+        {
+            // load the missing file
+            unsafeMappings.load( missingLicenses );
+        }
+        if ( useMissingFile && UrlRequester.isStringUrl( missingFileUrl ) )
+        {
+            String httpRequestResult = UrlRequester.getFromUrl( missingFileUrl );
+            unsafeMappings.load( new ByteArrayInputStream( httpRequestResult.getBytes() ) );
+        }
+
+        if ( !unsafeMappings.isEmpty() )
+        {
             Set<MavenProject> resolvedDependencies = new HashSet<>();
             for ( MavenProject unsafeDependency : unsafeDependencies )
             {

--- a/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
@@ -97,8 +97,7 @@ public class AggregatorAddThirdPartyMojo extends AbstractAddThirdPartyMojo
      * @deprecated since 1.14, please use now {@link #missingFile}.
      */
     @Deprecated
-    @Parameter( property = "license.aggregateMissingLicensesFile",
-                defaultValue = "${project.basedir}/src/license/THIRD-PARTY.properties" )
+    @Parameter( property = "license.aggregateMissingLicensesFile" )
     private File aggregateMissingLicensesFile;
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
@elballa these are all your changes from https://github.com/mojohaus/license-maven-plugin/pull/280 , I just just reorderd them to make more sense.