### PR TITLE
Fix #253 Add licenseMergesUrl also in report goals

### DIFF
--- a/src/it/aggregate-third-party-report-merge-licences/license.merges
+++ b/src/it/aggregate-third-party-report-merge-licences/license.merges
@@ -1,1 +1,2 @@
+MIT - MIT License|The MIT License|MIT License
 APACHE|The Apache Software License, Version 2.0|Apache License, Version 2.0|Apache Public License 2.0

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -777,7 +777,7 @@ public abstract class AbstractAddThirdPartyMojo
             getLog().warn( "" );
             if ( UrlRequester.isStringUrl( licenseMergesUrl ) )
             {
-                licenseMerges = Arrays.asList( UrlRequester.getFromUrl( licenseMergesUrl ).split( "\n" ) );
+                licenseMerges = Arrays.asList( UrlRequester.getFromUrl( licenseMergesUrl ).split( "[\n\r]+" ) );
             }
         }
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
@@ -392,7 +392,7 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport
             getLog().warn( "" );
             if ( UrlRequester.isStringUrl( licenseMergesUrl ) )
             {
-                licenseMerges = Arrays.asList( UrlRequester.getFromUrl( licenseMergesUrl ) );
+                licenseMerges = Arrays.asList( UrlRequester.getFromUrl( licenseMergesUrl ).split( "[\n\r]+" ) );
             }
         }
     }


### PR DESCRIPTION
There is still something missing in this fix #253. It should be included in next release because licenseMergeUrl in not reliable if there is more then one raw in content of file linked by licenseMergeUrl