### PR TITLE
Fix network proxy configuration

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/download/LicenseDownloader.java
+++ b/src/main/java/org/codehaus/mojo/license/download/LicenseDownloader.java
@@ -97,6 +97,11 @@ public class LicenseDownloader implements AutoCloseable
                         .setSocketTimeout( socketTimeout ) //
                         .setConnectionRequestTimeout( connectionRequestTimeout );
 
+        if ( proxy != null )
+        {
+            configBuilder.setProxy( new HttpHost( proxy.getHost(), proxy.getPort(), proxy.getProtocol() ) );
+        }
+
         HttpClientBuilder clientBuilder = HttpClients.custom().setDefaultRequestConfig( configBuilder.build() );
         if ( proxy != null )
         {


### PR DESCRIPTION
Unfortunately the currently used httpClient works
a little bit diffrently with the proxy settings.

With the old configuration the httpClient
allways gets a defaultRequestConfig without a
proxy set and so always tries a directly connection.