### PR TITLE
Fix #324 Remove unnecessary manual dependency resolution

### DIFF
--- a/src/it/ISSUE-324/README.txt
+++ b/src/it/ISSUE-324/README.txt
@@ -1,0 +1,5 @@
+Demonstrates that the aggregateAddThirdParty plugin only resolves the actually used version of a dependency, and not all versions that are present in transitive dependencies.
+
+The project contains a child2 that depends on hbase-annotations:2.1.3. It also contains child1 which depends on hive-hcatalog-core:2.3.4. The Hive dependency also depends on hbase-annotations, but in a much older version, and through a longer dependency chain. The old hbase-annotations artifact depends on jdk.tools, which is not present in Java 9+.
+
+The plugin execution will fail if the plugin attempts to resolve jdk.tools on Java 9+. This test is therefore only meaningful on Java 9+, and will pass spuriously on earlier versions.

--- a/src/it/ISSUE-324/child1/pom.xml
+++ b/src/it/ISSUE-324/child1/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-ISSUE-324</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <artifactId>test-ISSUE-324-child1</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+        <!-- Depends on old hbase-annotations, which depends on jdk.tools -->
+    <dependency>
+      <groupId>org.apache.hive.hcatalog</groupId>
+      <artifactId>hive-hcatalog-core</artifactId>
+      <version>2.3.4</version>
+    </dependency>
+        <!-- This has a newer hbase-annotations without jdk.tools. This path to hbase-annotations is shorter, so has precedence -->
+    <dependency>
+      <groupId>org.codehaus.mojo.license.test</groupId>
+      <artifactId>test-ISSUE-324-child2</artifactId>
+      <version>@pom.version@</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/ISSUE-324/child2/pom.xml
+++ b/src/it/ISSUE-324/child2/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.codehaus.mojo.license.test</groupId>
+    <artifactId>test-ISSUE-324</artifactId>
+    <version>@pom.version@</version>
+  </parent>
+  <artifactId>test-ISSUE-324-child2</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-annotations</artifactId>
+      <version>2.1.3</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/ISSUE-324/invoker.properties
+++ b/src/it/ISSUE-324/invoker.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+#
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean package -e
+invoker.failureBehavior=fail-fast

--- a/src/it/ISSUE-324/pom.xml
+++ b/src/it/ISSUE-324/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>test-ISSUE-324</artifactId>
+  <version>@pom.version@</version>
+  <name>License Test :: ISSUE-324</name>
+  <packaging>pom</packaging>
+
+  <licenses>
+    <license>
+      <name>The GNU Lesser General Public License, Version 3.0</name>
+      <url>http://www.gnu.org/licenses/lgpl-3.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <license.verbose>true</license.verbose>
+  </properties>
+
+  <modules>
+    <module>child1</module>
+    <module>child2</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <inherited>false</inherited>
+        <version>@pom.version@</version>
+        <configuration>
+          <excludedScopes>system,test</excludedScopes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generate-and-check-licenses</id>
+            <goals>
+              <goal>aggregate-add-third-party</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
@@ -565,8 +565,8 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport
         ResolvedProjectDependencies loadedDependencies;
         if ( loadArtifacts )
         {
-            loadedDependencies = dependenciesTool.loadProjectArtifacts( localRepository,
-                    project.getRemoteArtifactRepositories(), project, null );
+            loadedDependencies =
+                    new ResolvedProjectDependencies( project.getArtifacts(), project.getDependencyArtifacts() );
         }
         else
         {

--- a/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
@@ -238,8 +238,8 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
         }
         if ( isAggregatorBuild )
         {
-            dependencyArtifacts = dependenciesTool.loadProjectArtifacts( localRepository, remoteRepositories,
-                    project, reactorProjectDependencies );
+            dependencyArtifacts =
+                    new ResolvedProjectDependencies( project.getArtifacts(), project.getDependencyArtifacts() );
         }
         else
         {


### PR DESCRIPTION
Please see https://github.com/mojohaus/license-maven-plugin/issues/324

The fix here is to remove the manual dependency resolution in DependenciesTool. We already configure the mojos to require dependency resolution up to test scope, so all dependencies are already resolved and present in the injected MavenProject(s).

I realize that https://github.com/mojohaus/license-maven-plugin/issues/219 calls for programmatic dependency resolution, but I think that will be easier to implement once the plugin is upgraded to newer APIs. For now, the code in DependenciesTool is unnecessary and causes this bug.

I'll put up a PR for upgrading to Maven 3 APIs soon, which will depend on this PR.