### PR TITLE
Fix #326 Migrate to using Maven 3 APIs and Aether for dependency resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
   </distributionManagement>
 
   <properties>
-    <mavenVersion>2.2.1</mavenVersion>
+    <mavenVersion>3.5.4</mavenVersion>
     <mojo.java.target>1.7</mojo.java.target>
 
     <processorVersion>1.3</processorVersion>
@@ -132,6 +132,7 @@
 
     <pluginPluginVersion>3.5.1</pluginPluginVersion>
     <plexusComponentVersion>1.7.1</plexusComponentVersion>
+    <maven-resolver.version>1.3.3</maven-resolver.version>
   </properties>
 
   <dependencyManagement>
@@ -156,13 +157,13 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
+      <artifactId>maven-artifact</artifactId>
       <version>${mavenVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-      <version>${mavenVersion}</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${maven-resolver.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -255,7 +256,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-container-default</artifactId>
-      <version>1.0-alpha-9-stable-1</version>
+      <version>2.0.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/it/add-third-party-excluded-included/invoker.properties
+++ b/src/it/add-third-party-excluded-included/invoker.properties
@@ -19,5 +19,5 @@
 # <http://www.gnu.org/licenses/lgpl-3.0.html>.
 # #L%
 ###
-invoker.goals=clean validate
+invoker.goals=clean validate -e
 invoker.failureBehavior=fail-at-end

--- a/src/it/add-third-party-global-db/invoker.properties
+++ b/src/it/add-third-party-global-db/invoker.properties
@@ -19,5 +19,5 @@
 # <http://www.gnu.org/licenses/lgpl-3.0.html>.
 # #L%
 ###
-invoker.goals=clean package license:add-third-party
+invoker.goals=clean package license:add-third-party -e
 invoker.failureBehavior=fail-fast

--- a/src/it/aggregate-add-third-party-global-db/invoker.properties
+++ b/src/it/aggregate-add-third-party-global-db/invoker.properties
@@ -19,6 +19,6 @@
 # <http://www.gnu.org/licenses/lgpl-3.0.html>.
 # #L%
 ###
-invoker.goals=clean license:aggregate-add-third-party
+invoker.goals=clean license:aggregate-add-third-party -e
 invoker.failureBehavior=fail-at-end
 invoker.maven.version = 3.0 +

--- a/src/it/aggregate-add-third-party-missing-file/invoker.properties
+++ b/src/it/aggregate-add-third-party-missing-file/invoker.properties
@@ -19,5 +19,5 @@
 # <http://www.gnu.org/licenses/lgpl-3.0.html>.
 # #L%
 ###
-invoker.goals=clean license:aggregate-add-third-party@missing-file-only license:aggregate-add-third-party@missing-file-url-only license:aggregate-add-third-party@missing-file-both
+invoker.goals=clean license:aggregate-add-third-party@missing-file-only license:aggregate-add-third-party@missing-file-url-only license:aggregate-add-third-party@missing-file-both -e
 invoker.failureBehavior=fail-fast

--- a/src/it/third-party-report-global-db/invoker.properties
+++ b/src/it/third-party-report-global-db/invoker.properties
@@ -19,5 +19,5 @@
 # <http://www.gnu.org/licenses/lgpl-3.0.html>.
 # #L%
 ###
-invoker.goals=clean site:site
+invoker.goals=clean site:site -e
 invoker.failureBehavior=fail-fast

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -27,8 +27,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
-import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
@@ -59,6 +57,8 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import org.codehaus.mojo.license.api.DependenciesToolException;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.transfer.ArtifactNotFoundException;
 
 /**
  * Abstract mojo for all third-party mojos.
@@ -593,14 +593,6 @@ public abstract class AbstractAddThirdPartyMojo
     protected ArtifactRepository localRepository;
 
     /**
-     * Remote repositories used for the project.
-     *
-     * @since 1.0.0
-     */
-    @Parameter( property = "project.remoteArtifactRepositories", required = true, readonly = true )
-    protected List<ArtifactRepository> remoteRepositories;
-
-    /**
      * The set of dependencies for the current project, used to locate license databases.
      */
     @Parameter( property = "project.artifacts", required = true, readonly = true )
@@ -881,7 +873,8 @@ public abstract class AbstractAddThirdPartyMojo
         if ( helper == null )
         {
             helper = new DefaultThirdPartyHelper( getProject(), getEncoding(), isVerbose(), dependenciesTool,
-                    thirdPartyTool, localRepository, remoteRepositories, getLog() );
+                    thirdPartyTool, getProject().getRemoteArtifactRepositories(),
+                    getProject().getRemoteProjectRepositories(), getLog() );
         }
         return helper;
     }
@@ -890,7 +883,7 @@ public abstract class AbstractAddThirdPartyMojo
       throws ArtifactNotFoundException, IOException, ArtifactResolutionException, MojoExecutionException
     {
         File missingLicensesFromArtifact = thirdPartyTool.resolveMissingLicensesDescriptor( groupId, artifactId,
-                version, localRepository, remoteRepositories );
+                version, getProject().getRemoteProjectRepositories() );
         resolveUnsafeDependenciesFromFile( missingLicensesFromArtifact );
     }
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -80,14 +80,6 @@ public abstract class AbstractDownloadLicensesMojo
     // ----------------------------------------------------------------------
 
     /**
-     * Location of the local repository.
-     *
-     * @since 1.0
-     */
-    @Parameter( defaultValue = "${localRepository}", readonly = true )
-    protected ArtifactRepository localRepository;
-
-    /**
      * List of Remote Repositories used by the resolver
      *
      * @since 1.0

--- a/src/main/java/org/codehaus/mojo/license/AbstractLicensesXmlMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractLicensesXmlMojo.java
@@ -84,14 +84,6 @@ public abstract class AbstractLicensesXmlMojo
     private String licensesOutputFileEncoding;
 
     /**
-     * Location of the local repository.
-     *
-     * @since 1.0
-     */
-    @Parameter( defaultValue = "${localRepository}", readonly = true )
-    protected ArtifactRepository localRepository;
-
-    /**
      * List of Remote Repositories used by the resolver
      *
      * @since 1.0
@@ -108,12 +100,12 @@ public abstract class AbstractLicensesXmlMojo
     protected MavenProject project;
 
     /**
-     * Dependencies tool.
+     * Licensed artifact resolver.
      *
      * @since 1.0
      */
     @Component
-    protected LicensedArtifactResolver dependenciesTool;
+    protected LicensedArtifactResolver licensedArtifactResolver;
 
     private Charset charset;
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
@@ -23,7 +23,6 @@ package org.codehaus.mojo.license;
  */
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.doxia.siterenderer.Renderer;
@@ -302,14 +301,6 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport
     private String encoding;
 
     /**
-     * Local Repository.
-     *
-     * @since 1.1
-     */
-    @Parameter( property = "localRepository", required = true, readonly = true )
-    private ArtifactRepository localRepository;
-
-    /**
      * The Maven Project.
      *
      * @since 1.1
@@ -434,10 +425,6 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport
             throw new MavenReportException( e.getMessage(), e );
         }
         catch ( ProjectBuildingException e )
-        {
-            throw new MavenReportException( e.getMessage(), e );
-        }
-        catch ( InvalidDependencyVersionException e )
         {
             throw new MavenReportException( e.getMessage(), e );
         }
@@ -577,7 +564,7 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport
         ThirdPartyHelper thirdPartyHelper =
                 new DefaultThirdPartyHelper( project, encoding, verbose,
                         dependenciesTool, thirdPartyTool,
-                        localRepository, project.getRemoteArtifactRepositories(), getLog() );
+                        project.getRemoteArtifactRepositories(), project.getRemoteProjectRepositories(), getLog() );
         // load dependencies of the project
         SortedMap<String, MavenProject> projectDependencies = thirdPartyHelper.loadDependencies( this,
                 loadedDependencies );
@@ -649,6 +636,5 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport
     {
         return encoding;
     }
-
 
 }

--- a/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
@@ -442,8 +442,7 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
         resolvedOverrideUrl  = mojo.resolvedOverrideUrl;
         missingLicensesFileArtifact = mojo.missingLicensesFileArtifact;
         localRepository = mojo.localRepository;
-        remoteRepositories = mavenProject.getRemoteArtifactRepositories();
-        dependencies = new HashSet<>( mavenProject.getDependencies() );
+        dependencies = new HashSet<>( mavenProject.getDependencyArtifacts() );
         licenseMerges = mojo.licenseMerges;
         licenseMergesFile = mojo.licenseMergesFile;
         includedLicenses = mojo.includedLicenses;

--- a/src/main/java/org/codehaus/mojo/license/AggregateDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AggregateDownloadLicensesMojo.java
@@ -115,9 +115,9 @@ public class AggregateDownloadLicensesMojo
 
         for ( MavenProject p : reactorProjects )
         {
-            dependenciesTool.loadProjectDependencies( new ResolvedProjectDependencies( p.getArtifacts(),
+            licensedArtifactResolver.loadProjectDependencies( new ResolvedProjectDependencies( p.getArtifacts(),
                                                                                        p.getDependencyArtifacts() ),
-                                                      this, localRepository, remoteRepositories, result );
+                                                      this, remoteRepositories, result );
         }
         return result;
     }

--- a/src/main/java/org/codehaus/mojo/license/DownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/DownloadLicensesMojo.java
@@ -86,9 +86,9 @@ public class DownloadLicensesMojo
     protected Map<String, LicensedArtifact> getDependencies()
     {
         final Map<String, LicensedArtifact> result = new TreeMap<>();
-        dependenciesTool.loadProjectDependencies(
+        licensedArtifactResolver.loadProjectDependencies(
                 new ResolvedProjectDependencies( project.getArtifacts(), project.getDependencyArtifacts() ),
-                this, localRepository, remoteRepositories, result );
+                this, remoteRepositories, result );
         return result;
     }
 

--- a/src/main/java/org/codehaus/mojo/license/LicensesXmlInsertVersionsMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/LicensesXmlInsertVersionsMojo.java
@@ -137,9 +137,9 @@ public class LicensesXmlInsertVersionsMojo
                 }
             };
             final Map<String, LicensedArtifact> resolvedDeps = new TreeMap<String, LicensedArtifact>();
-            dependenciesTool.loadProjectDependencies(
+            licensedArtifactResolver.loadProjectDependencies(
                     new ResolvedProjectDependencies( project.getArtifacts(), project.getDependencyArtifacts() ),
-                                                     config, localRepository, remoteRepositories, resolvedDeps );
+                                                     config, remoteRepositories, resolvedDeps );
             final Map<String, LicensedArtifact> resolvedDepsMap = new HashMap<>( resolvedDeps.size() );
             for ( LicensedArtifact dep : resolvedDeps.values() )
             {

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
+import org.eclipse.aether.repository.RemoteRepository;
 
 /**
  * Default implementation of the {@link org.codehaus.mojo.license.api.ThirdPartyHelper}.
@@ -71,14 +72,14 @@ public class DefaultThirdPartyHelper
     private final ThirdPartyTool thirdPartyTool;
 
     /**
-     * Local repository used.
+     * List of remote repositories. Same as remoteRepositories, just a different API.
      */
-    private final ArtifactRepository localRepository;
+    private final List<ArtifactRepository> remoteRepositoriesCoreApi;
 
     /**
      * List of remote repositories.
      */
-    private final List<ArtifactRepository> remoteRepositories;
+    private final List<RemoteRepository> remoteRepositories;
 
     /**
      * Current maven project.
@@ -113,15 +114,15 @@ public class DefaultThirdPartyHelper
      * @param verbose            Verbose flag
      * @param dependenciesTool   tool to load dependencies
      * @param thirdPartyTool     tool to load third-parties descriptors
-     * @param localRepository    maven local repository
+     * @param remoteRepositoriesCoreApi maven remote repositories, in the core api format
      * @param remoteRepositories maven remote repositories
      * @param log                logger
      */
     // CHECKSTYLE_OFF: ParameterNumber
     public DefaultThirdPartyHelper( MavenProject project, String encoding, boolean verbose,
                                     DependenciesTool dependenciesTool, ThirdPartyTool thirdPartyTool,
-                                    ArtifactRepository localRepository, List<ArtifactRepository> remoteRepositories,
-                                    Log log )
+                                    List<ArtifactRepository> remoteRepositoriesCoreApi,
+                                    List<RemoteRepository> remoteRepositories, Log log )
     {
         // CHECKSTYLE_ON: ParameterNumber
         this.project = project;
@@ -129,7 +130,7 @@ public class DefaultThirdPartyHelper
         this.verbose = verbose;
         this.dependenciesTool = dependenciesTool;
         this.thirdPartyTool = thirdPartyTool;
-        this.localRepository = localRepository;
+        this.remoteRepositoriesCoreApi = remoteRepositoriesCoreApi;
         this.remoteRepositories = remoteRepositories;
         this.log = log;
         this.thirdPartyTool.setVerbose( verbose );
@@ -153,8 +154,8 @@ public class DefaultThirdPartyHelper
     public SortedMap<String, MavenProject> loadDependencies( MavenProjectDependenciesConfigurator configuration,
                                                              ResolvedProjectDependencies dependencyArtifacts )
     {
-        return dependenciesTool.loadProjectDependencies( dependencyArtifacts, configuration, localRepository,
-                remoteRepositories, getArtifactCache() );
+        return dependenciesTool.loadProjectDependencies( dependencyArtifacts, configuration,
+                remoteRepositoriesCoreApi, getArtifactCache() );
     }
 
     /**
@@ -167,8 +168,7 @@ public class DefaultThirdPartyHelper
             throws ThirdPartyToolException, IOException
     {
         return thirdPartyTool.loadThirdPartyDescriptorsForUnsafeMapping( topLevelDependencies, encoding, projects,
-                                                                         unsafeDependencies, licenseMap,
-                                                                         localRepository, remoteRepositories );
+                unsafeDependencies, licenseMap, remoteRepositories );
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/license/api/ThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/ThirdPartyTool.java
@@ -23,9 +23,6 @@ package org.codehaus.mojo.license.api;
  */
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
-import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.model.License;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
@@ -39,6 +36,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.transfer.ArtifactNotFoundException;
 
 /**
  * A tool to load third party files missing files.
@@ -81,7 +81,6 @@ public interface ThirdPartyTool
      * @param projects           all projects where to read third parties descriptors
      * @param unsafeProjects     all unsafe projects
      * @param licenseMap         license map where to store new licenses
-     * @param localRepository    local repository
      * @param remoteRepositories remote repositories
      * @return the map of loaded missing from the remote missing third party files
      * @throws ThirdPartyToolException if any
@@ -91,8 +90,7 @@ public interface ThirdPartyTool
                                                                 Collection<MavenProject> projects,
                                                                 SortedSet<MavenProject> unsafeProjects,
                                                                 LicenseMap licenseMap,
-                                                                ArtifactRepository localRepository,
-                                                                List<ArtifactRepository> remoteRepositories )
+                                                                List<RemoteRepository> remoteRepositories )
             throws ThirdPartyToolException, IOException;
 
     /**
@@ -108,20 +106,18 @@ public interface ThirdPartyTool
     /**
      * Obtain the third party file from the repository.
      * <p>
-     * Will first search in the local repository, then into the remote repositories and will resolv it.
+     * Will first search in the local repository, then into the remote repositories and will resolve it.
      *
      * @param project         the project
-     * @param localRepository the local repository
-     * @param repositories    the remote repositories
+     * @param remoteRepositories    the remote repositories
      * @return the locale file resolved into the local repository
      * @throws ThirdPartyToolException if any
      */
-    File resolvThirdPartyDescriptor( MavenProject project, ArtifactRepository localRepository,
-                                     List<ArtifactRepository> repositories )
+    File resolvThirdPartyDescriptor( MavenProject project, List<RemoteRepository> remoteRepositories )
             throws ThirdPartyToolException;
 
     File resolveMissingLicensesDescriptor( String groupId, String artifactId, String version,
-                                           ArtifactRepository localRepository, List<ArtifactRepository> repositories )
+                                     List<RemoteRepository> remoteRepositories )
             throws IOException, ArtifactResolutionException, ArtifactNotFoundException;
 
     /**


### PR DESCRIPTION
Based on https://github.com/mojohaus/license-maven-plugin/issues/324, please look at that one first.

This migrates the plugin to Maven 3 dependencies, and also replaces the old ArtifactResolver with maven-resolver.

The version requirement here is at least 3.5.0, as maven-resolver-provider is not present in prior versions. For now I've set the plugin to need 3.6.1, as that was what I tested with. 