### PR TITLE
Fix #328 Publish integration test build directory when Appveyor build…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,3 +12,7 @@ build_script:
 cache:
   - C:\Users\appveyor\.m2\repository
   - C:\Users\appveyor\.m2\wrapper
+
+on_failure:
+  - 7z a it-logs.zip target\it
+  - appveyor PushArtifact it-logs.zip


### PR DESCRIPTION
… fails

Tested by asserting false in one of the tests.

Example failed build: https://ci.appveyor.com/project/ppalaga/license-maven-plugin-g0x55/builds/24016667/job/ywjj0tb5j48y8grl/artifacts