### PR TITLE
Fix #331 overrideUrl doesn't work

### DIFF
--- a/src/test/java/org/codehaus/mojo/license/LicenseMojoUtilsTest.java
+++ b/src/test/java/org/codehaus/mojo/license/LicenseMojoUtilsTest.java
@@ -1,0 +1,165 @@
+package org.codehaus.mojo.license;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.Test;
+
+public class LicenseMojoUtilsTest
+{
+    private String resolvedUrl;
+    private File deprecatedFile;
+    private String url;
+    private File basedir = new File( "" );
+    private MockLogger log = new MockLogger();
+
+    @Test
+    public void testIsValidNull()
+    {
+        assertFalse( LicenseMojoUtils.isValid( null ) );
+    }
+
+    @Test
+    public void testIsValidEmpty()
+    {
+        // This might be wrong; feel free to change the test when it starts to fail
+        assertTrue( LicenseMojoUtils.isValid( "" ) );
+    }
+
+    @Test
+    public void testIsValidBlank()
+    {
+        // This might be wrong; feel free to change the test when it starts to fail
+        assertTrue( LicenseMojoUtils.isValid( "   " ) );
+    }
+
+    @Test
+    public void testIsValidNonexistingClasspathResource()
+    {
+        assertTrue( LicenseMojoUtils.isValid( "classpath:noSuchResource" ) );
+    }
+
+    @Test
+    public void testIsValidClasspathResource()
+    {
+        assertTrue( LicenseMojoUtils.isValid( "classpath:log4j.properties" ) );
+    }
+
+    @Test
+    public void testIsValidHttpResource()
+    {
+        assertTrue( LicenseMojoUtils.isValid( "http://foo/bar/baz" ) );
+    }
+
+    @Test
+    public void testPrepareThirdPartyOverrideUrlNull()
+    {
+        String actual = LicenseMojoUtils.prepareThirdPartyOverrideUrl( resolvedUrl, deprecatedFile, url, basedir, log );
+        assertEquals( LicenseMojoUtils.NO_URL, actual );
+    }
+
+    @Test
+    public void testPrepareThirdPartyOverrideUrlBothOverrides()
+    {
+        deprecatedFile = new File( "src/test/resources/overrides.properties" );
+        url = "classpath:overrides.properties";
+        try
+        {
+            LicenseMojoUtils.prepareThirdPartyOverrideUrl( resolvedUrl, deprecatedFile, url, basedir, log );
+
+            fail( "Missing exception" );
+        }
+        catch( IllegalArgumentException e )
+        {
+            assertEquals( "You can't use both overrideFile and overrideUrl", e.getMessage() );
+        }
+    }
+
+    @Test
+    public void testPrepareThirdPartyOverrideUrlNonExistingDeprecatedFile()
+    {
+        deprecatedFile = new File( "foo" );
+        String actual = runTestAndJoinResults();
+        assertEquals(
+                "resolved=file:///inexistent\n"
+                + "valid=false\n"
+                + "WARN 'overrideFile' mojo parameter is deprecated. Use 'overrideUrl' instead.\n"
+                + "WARN overrideFile [.../foo] was configured but doesn't exist\n"
+                + "DEBUG No (valid) URL and no file [.../override-THIRD-PARTY.properties] found; not loading any overrides"
+                , actual );
+    }
+
+    @Test
+    public void testPrepareThirdPartyOverrideUrlDeprecatedFile()
+    {
+        deprecatedFile = new File( "src/test/resources/overrides.properties" );
+        String actual = runTestAndJoinResults();
+        assertEquals(
+                "resolved=file:/.../overrides.properties\n"
+                + "valid=true\n"
+                + "WARN 'overrideFile' mojo parameter is deprecated. Use 'overrideUrl' instead.\n"
+                + "DEBUG Loading overrides from file file:/.../overrides.properties"
+                , actual );
+    }
+
+    @Test
+    public void testPrepareThirdPartyOverrideClasspathResource()
+    {
+        url = "classpath:overrides.properties";
+        String actual = LicenseMojoUtils.prepareThirdPartyOverrideUrl( resolvedUrl, deprecatedFile, url, basedir, log );
+        assertEquals( url, actual );
+        assertTrue( LicenseMojoUtils.isValid(actual) );
+        assertEquals( "DEBUG Loading overrides from URL classpath:overrides.properties", log.dump() );
+    }
+
+    @Test
+    public void testPrepareThirdPartyOverrideInvalidUrl()
+    {
+        url = "foo://localhost/bar";
+        String actual = runTestAndJoinResults();
+        assertEquals(
+                "resolved=file:///inexistent\n"
+                + "valid=false\n"
+                + "WARN Unsupported or invalid URL [foo://localhost/bar] found in overrideUrl; supported are 'classpath:' URLs and  anything your JVM supports (file:, http: and https: should always work)\n"
+                + "DEBUG No (valid) URL and no file [.../override-THIRD-PARTY.properties] found; not loading any overrides"
+                , actual );
+    }
+
+    @Test
+    public void testPrepareThirdPartyOverridePreventReinit()
+    {
+        resolvedUrl = "classpath:overrides.properties";
+        deprecatedFile = new File( "foo" );
+        url = "classpath:bar";
+        String actual = runTestAndJoinResults();
+        assertEquals(
+                "resolved=classpath:overrides.properties\n"
+                + "valid=true\n"
+                + "WARN 'overrideFile' mojo parameter is deprecated. Use 'overrideUrl' instead."
+                , actual );
+    }
+
+    /** Allow to validate several test results in one assert */
+    private String runTestAndJoinResults()
+    {
+        String result = LicenseMojoUtils.prepareThirdPartyOverrideUrl( resolvedUrl, deprecatedFile, url, basedir, log );
+        File defaultOverride = new File ( LicenseMojoUtils.DEFAULT_OVERRIDE_THIRD_PARTY );
+        String dump = log.dump()
+                .replace( defaultOverride.getAbsolutePath(), ".../" + defaultOverride.getName() );
+
+        if ( deprecatedFile != null )
+        {
+            dump = dump
+                    .replace( deprecatedFile.toURI().toString(), "file:/.../" + deprecatedFile.getName() )
+                    .replace( deprecatedFile.getAbsolutePath(), ".../" + deprecatedFile.getName() );
+            result = result
+                    .replace( deprecatedFile.toURI().toString(), "file:/.../" + deprecatedFile.getName() );
+        }
+
+        String actual = "resolved=" + result + "\n"
+                + "valid=" + LicenseMojoUtils.isValid( result ) + "\n"
+                + dump;
+        return actual;
+    }
+}

--- a/src/test/java/org/codehaus/mojo/license/MockLogger.java
+++ b/src/test/java/org/codehaus/mojo/license/MockLogger.java
@@ -1,0 +1,178 @@
+package org.codehaus.mojo.license;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.util.StringUtils;
+
+public class MockLogger implements Log
+{
+    private boolean debugEnabled = true;
+    private boolean infoEnabled = true;
+    private boolean warnEnabled = true;
+    private boolean errorEnabled = true;
+    private List<String> messages = new ArrayList<>();
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return debugEnabled;
+    }
+
+    @Override
+    public void debug( CharSequence content )
+    {
+        add( debugEnabled, "DEBUG", content );
+    }
+
+    @Override
+    public void debug( CharSequence content, Throwable error )
+    {
+        add( debugEnabled, "DEBUG", content, error );
+    }
+
+    @Override
+    public void debug( Throwable error )
+    {
+        add( debugEnabled, "DEBUG", error );
+    }
+
+    @Override
+    public boolean isInfoEnabled()
+    {
+        return infoEnabled;
+    }
+
+    @Override
+    public void info( CharSequence content )
+    {
+        add( infoEnabled, "INFO", content );
+    }
+
+    @Override
+    public void info( CharSequence content, Throwable error )
+    {
+        add( infoEnabled, "INFO", content, error );
+    }
+
+    @Override
+    public void info( Throwable error )
+    {
+        add( infoEnabled, "INFO", error );
+    }
+
+    @Override
+    public boolean isWarnEnabled()
+    {
+        return warnEnabled;
+    }
+
+    @Override
+    public void warn( CharSequence content )
+    {
+        add( warnEnabled, "WARN", content );
+    }
+
+    @Override
+    public void warn( CharSequence content, Throwable error )
+    {
+        add( warnEnabled, "WARN", content, error );
+    }
+
+    @Override
+    public void warn( Throwable error )
+    {
+        add( warnEnabled, "WARN", error );
+    }
+
+    @Override
+    public boolean isErrorEnabled()
+    {
+        return errorEnabled;
+    }
+
+    @Override
+    public void error( CharSequence content )
+    {
+        add( errorEnabled, "ERROR", content );
+    }
+
+    @Override
+    public void error( CharSequence content, Throwable error )
+    {
+        add( errorEnabled, "ERROR", content, error );
+    }
+
+    @Override
+    public void error( Throwable error )
+    {
+        add( errorEnabled, "ERROR", error );
+    }
+
+    // Builder pattern initialization
+
+    public MockLogger enableDebug( boolean enable )
+    {
+        debugEnabled = enable;
+        return this;
+    }
+
+    public MockLogger enableInfo( boolean enable )
+    {
+        infoEnabled = enable;
+        return this;
+    }
+
+    public MockLogger enableWarn( boolean enable )
+    {
+        warnEnabled = enable;
+        return this;
+    }
+
+    public MockLogger enableError( boolean enable )
+    {
+        errorEnabled = enable;
+        return this;
+    }
+
+    private void add(boolean enabled, String level, Throwable error) {
+        add(enabled, level, null, error);
+    }
+
+    private void add(boolean enabled, String level, CharSequence content) {
+        add(enabled, level, content, null);
+    }
+
+    private void add(boolean enabled, String level, CharSequence content, Throwable error) {
+        if (!enabled) {
+            return;
+        }
+
+        StringBuilder buffer = new StringBuilder(level);
+        if (content != null) {
+            buffer.append( ' ' ).append(content);
+        }
+
+        if (error != null) {
+            buffer.append( "\n" ).append(error.toString());
+        }
+
+        messages.add( buffer.toString() );
+    }
+
+    public List<String> getMessages()
+    {
+        return messages;
+    }
+
+    public String dump()
+    {
+        return StringUtils.join( messages.iterator(), "\n" );
+    }
+
+    public void reset()
+    {
+        messages.clear();
+    }
+}

--- a/src/test/resources/overrides.properties
+++ b/src/test/resources/overrides.properties
@@ -1,0 +1,1 @@
+org.jboss.xnio--xnio-api--3.3.6.Final=The Apache Software License, Version 2.0


### PR DESCRIPTION
In addition to just checking the result, I've also added logging so users of the plugin can find out what it's loading and from where and why without having to start a debugger.

Code coverage is at 83.9%

Sore point is the DEFAULT_OVERRIDE_THIRD_PARTY which is used in the default path of the code; I could wrap the constant in a getter to switch between "exists" and "missing" cases.