### PR TITLE
Feature/201 omit unknown dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,10 +301,9 @@
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-      <scope>runtime</scope>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.26</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -731,6 +731,8 @@ public abstract class AbstractAddThirdPartyMojo
 
         Log log = getLog();
 
+        thirdPartyTool.setUnknownDependencyStrategy( unknownDependencyStrategy );
+
         if ( log.isDebugEnabled() )
         {
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractThirdPartyReportMojo.java
@@ -45,6 +45,7 @@ import org.codehaus.mojo.license.api.ThirdPartyDetails;
 import org.codehaus.mojo.license.api.ThirdPartyHelper;
 import org.codehaus.mojo.license.api.ThirdPartyTool;
 import org.codehaus.mojo.license.api.ThirdPartyToolException;
+import org.codehaus.mojo.license.api.UnknownDependencyStrategyFactory;
 import org.codehaus.mojo.license.model.LicenseMap;
 import org.codehaus.mojo.license.utils.MojoHelper;
 import org.codehaus.mojo.license.utils.UrlRequester;
@@ -370,6 +371,17 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport
     @Parameter( property = "license.artifactFiltersUrl" )
     private String artifactFiltersUrl;
 
+    /**
+     * What to do when a license is specified in either the missing or override files:
+     * <li>
+     *   <ul>{@link UnknownDependencyStrategyFactory.Strategy#ignore}: all errors are ignored</ul>
+     *   <ul>{@link UnknownDependencyStrategyFactory.Strategy#warn}: all errors are output to the log as warnings</ul>
+     * </li>
+     * @since 1.21
+     */
+    @Parameter( property = "license.unknownDependencyStrategy", defaultValue = "warn" )
+    protected UnknownDependencyStrategyFactory.Strategy unknownDependencyStrategy;
+
     private ArtifactFilters artifactFilters;
 
     // ----------------------------------------------------------------------
@@ -394,6 +406,8 @@ public abstract class AbstractThirdPartyReportMojo extends AbstractMavenReport
     protected void init()
             throws IOException
     {
+        thirdPartyTool.setUnknownDependencyStrategy( unknownDependencyStrategy );
+
         if ( licenseMergesUrl != null )
         {
             getLog().warn( "" );

--- a/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AddThirdPartyMojo.java
@@ -69,7 +69,6 @@ import org.codehaus.mojo.license.utils.SortedProperties;
        defaultPhase = LifecyclePhase.GENERATE_RESOURCES )
 public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements MavenProjectDependenciesConfigurator
 {
-
     // ----------------------------------------------------------------------
     // Mojo Parameters
     // ----------------------------------------------------------------------
@@ -257,9 +256,9 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
       throws ProjectBuildingException, IOException, ThirdPartyToolException,
             MojoExecutionException, DependenciesToolException
     {
-
         SortedProperties unsafeMappings =
-                getHelper().createUnsafeMapping( licenseMap, missingFile, missingFileUrl,
+                getHelper().createUnsafeMapping( licenseMap,
+                                                 createMissingLicensesProvider(),
                                                  useRepositoryMissingFiles, unsafeDependencies,
                                                  projectDependencies,
                                                  resolveDependencyArtifacts().getAllDependencies() );
@@ -458,6 +457,7 @@ public class AddThirdPartyMojo extends AbstractAddThirdPartyMojo implements Mave
         session = mojo.session;
         verbose = mojo.verbose;
         encoding = mojo.encoding;
+        unknownDependencyStrategy = mojo.unknownDependencyStrategy;
 
         setLog( mojo.getLog() );
 

--- a/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
@@ -40,6 +40,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingException;
+import org.codehaus.mojo.license.api.SortedPropertiesProvider;
+import org.codehaus.mojo.license.api.impl.SortedPropertiesFileProvider;
 import org.codehaus.mojo.license.model.LicenseMap;
 import org.codehaus.mojo.license.utils.SortedProperties;
 
@@ -60,6 +62,7 @@ import org.codehaus.mojo.license.utils.SortedProperties;
         requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true )
 public class AggregatorAddThirdPartyMojo extends AbstractAddThirdPartyMojo
 {
+
     // ----------------------------------------------------------------------
     // Mojo Parameters
     // ----------------------------------------------------------------------
@@ -292,8 +295,11 @@ public class AggregatorAddThirdPartyMojo extends AbstractAddThirdPartyMojo
 
             if ( file.exists() )
             {
-
-                SortedProperties tmp = getHelper().loadUnsafeMapping( licenseMap, file, null, projectDependencies );
+                SortedPropertiesProvider missingLicensesProvider =
+                        new SortedPropertiesFileProvider( file, null );
+                // TODO is p == getProject()??
+                SortedProperties tmp = getHelper().loadUnsafeMapping( p, licenseMap, missingLicensesProvider,
+                        projectDependencies );
                 unsafeMappings.putAll( tmp );
             }
 

--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyHelper.java
@@ -174,12 +174,14 @@ public class DefaultThirdPartyHelper
     /**
      * {@inheritDoc}
      */
-    public SortedProperties loadUnsafeMapping( LicenseMap licenseMap, File missingFile, String missingFileUrl,
-                                               SortedMap<String, MavenProject> projectDependencies )
+    public SortedProperties loadUnsafeMapping(
+            MavenProject reactorProject,
+            LicenseMap licenseMap, SortedPropertiesProvider missingLicensesProvider,
+            SortedMap<String, MavenProject> projectDependencies )
       throws IOException, MojoExecutionException
     {
-        return thirdPartyTool.loadUnsafeMapping( licenseMap, projectDependencies, encoding, missingFile,
-                missingFileUrl );
+        return thirdPartyTool.loadUnsafeMapping( reactorProject, licenseMap, projectDependencies,
+                missingLicensesProvider );
     }
 
     /**
@@ -218,7 +220,8 @@ public class DefaultThirdPartyHelper
     /**
      * {@inheritDoc}
      */
-    public SortedProperties createUnsafeMapping( LicenseMap licenseMap, File missingFile, String missingFileUrl,
+    public SortedProperties createUnsafeMapping( LicenseMap licenseMap,
+                                                 SortedPropertiesProvider missingLicensesProvider,
                                                  boolean useRepositoryMissingFiles,
                                                  SortedSet<MavenProject> unsafeDependencies,
                                                  SortedMap<String, MavenProject> projectDependencies,
@@ -226,8 +229,8 @@ public class DefaultThirdPartyHelper
       throws ProjectBuildingException, IOException, ThirdPartyToolException, MojoExecutionException
     {
 
-        SortedProperties unsafeMappings = loadUnsafeMapping( licenseMap, missingFile, missingFileUrl,
-                                                             projectDependencies );
+        SortedProperties unsafeMappings = loadUnsafeMapping( project, licenseMap,
+                missingLicensesProvider, projectDependencies );
 
         if ( CollectionUtils.isNotEmpty( unsafeDependencies ) )
         {

--- a/src/main/java/org/codehaus/mojo/license/api/SortedPropertiesProvider.java
+++ b/src/main/java/org/codehaus/mojo/license/api/SortedPropertiesProvider.java
@@ -1,0 +1,66 @@
+package org.codehaus.mojo.license.api;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.io.IOException;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import org.codehaus.mojo.license.utils.SortedProperties;
+
+/**
+ * Provide additional licenses, for example when projects
+ * don't specify a license.
+ */
+public interface SortedPropertiesProvider
+{
+    /**
+     * Returns a copy of the additional licenses.
+     *
+     * <p>You will get a new copy every time you call this
+     * method.
+     *
+     * @return mutable copy of the additional licenses.
+     */
+    SortedProperties get() throws IOException;
+}

--- a/src/main/java/org/codehaus/mojo/license/api/SortedPropertiesProviderFactory.java
+++ b/src/main/java/org/codehaus/mojo/license/api/SortedPropertiesProviderFactory.java
@@ -1,0 +1,79 @@
+package org.codehaus.mojo.license.api;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.io.File;
+
+import org.codehaus.mojo.license.api.impl.EmptySortedPropertiesProvider;
+import org.codehaus.mojo.license.api.impl.SortedPropertiesFileProvider;
+import org.codehaus.mojo.license.api.impl.SortedPropertiesUrlProvider;
+import org.codehaus.mojo.license.utils.UrlRequester;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provide additional licenses, for example when projects
+ * don't specify a license.
+ *
+ * @since 1.21
+ */
+public class SortedPropertiesProviderFactory
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger( SortedPropertiesProviderFactory.class );
+
+    private final String encoding;
+
+    public SortedPropertiesProviderFactory( String encoding )
+    {
+        this.encoding = encoding;
+    }
+
+    /**
+     * Returns a copy of the additional licenses.
+     *
+     * <p>You will get a new copy every time you call this
+     * method.
+     *
+     * @return mutable copy of the additional licenses.
+     */
+    public SortedPropertiesProvider build( File file, String url )
+    {
+        if ( file != null )
+        {
+            if ( file.exists() )
+            {
+                return new SortedPropertiesFileProvider( file, encoding );
+            }
+
+            LOGGER.debug( "No such file: {}", file.getAbsolutePath() );
+        }
+
+        if ( UrlRequester.isStringUrl( url ) )
+        {
+            return new SortedPropertiesUrlProvider( url );
+        }
+
+        return new EmptySortedPropertiesProvider();
+
+    }
+}

--- a/src/main/java/org/codehaus/mojo/license/api/ThirdPartyHelper.java
+++ b/src/main/java/org/codehaus/mojo/license/api/ThirdPartyHelper.java
@@ -80,16 +80,16 @@ public interface ThirdPartyHelper
      * Load unsafe mapping for all dependencies with no license in their pom, we will load the missing file
      * if it exists and also add all dependencies from licenseMap with no license known.
      *
+     * @param reactorProject      the current project.
      * @param licenseMap          the license map of all dependencies.
-     * @param missingFile         location of an optional missing fille (says where you fix missing license).
-     * @param missingFileUrl      location of an optional missing file extension that can be downloaded from some
-     *                            resource hoster and that will be merged with the content of the missing file.
+     * @param missingLicenseProvider Provides missing licenses
      * @param projectDependencies project dependencies used to detect which dependencies in the missing file
      *                            are unknown to the project.
      * @return the map of all unsafe mapping
      * @throws IOException if could not load missing file
      */
-    SortedProperties loadUnsafeMapping( LicenseMap licenseMap, File missingFile, String missingFileUrl,
+    SortedProperties loadUnsafeMapping( MavenProject reactorProject, LicenseMap licenseMap,
+                                        SortedPropertiesProvider missingLicenseProvider,
                                         SortedMap<String, MavenProject> projectDependencies )
       throws IOException, MojoExecutionException;
 
@@ -97,7 +97,7 @@ public interface ThirdPartyHelper
      * Creates a license map from given dependencies.
      *
      * @param dependencies dependencies to store in the license map
-     * @return the created license map fro the given dependencies
+     * @return the created license map for the given dependencies
      */
     LicenseMap createLicenseMap( SortedMap<String, MavenProject> dependencies );
 
@@ -152,7 +152,8 @@ public interface ThirdPartyHelper
      * @throws IOException              if could not load missing file
      * @throws ThirdPartyToolException  if pb with third-party tool
      */
-    SortedProperties createUnsafeMapping( LicenseMap licenseMap, File missingFile, String missingFileUrl,
+    SortedProperties createUnsafeMapping( LicenseMap licenseMap,
+                                          SortedPropertiesProvider missingLicensesProvider,
                                           boolean useRepositoryMissingFiles,
                                           SortedSet<MavenProject> unsafeDependencies,
                                           SortedMap<String, MavenProject> projectDependencies,

--- a/src/main/java/org/codehaus/mojo/license/api/ThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/ThirdPartyTool.java
@@ -73,6 +73,22 @@ public interface ThirdPartyTool
     void setVerbose( boolean verbose );
 
     /**
+     * Get the strategy to handle unknown dependencies.
+     *
+     * @param The strategy in use
+     * @since 1.21
+     */
+    UnknownDependencyStrategyFactory.Strategy getUnknownDependencyStrategy();
+
+    /**
+     * Defines the strategy to handle unknown dependencies.
+     *
+     * @param strategy to use
+     * @since 1.21
+     */
+    void setUnknownDependencyStrategy( UnknownDependencyStrategyFactory.Strategy strategy );
+
+    /**
      * Collect license information from property file, 'third-party' classified artifacts, and .license.properties
      * dependencies.
      *
@@ -132,6 +148,7 @@ public interface ThirdPartyTool
     /**
      * Loads unsafe mapping and returns it.
      *
+     * @param reactorProject  current project
      * @param licenseMap      license map
      * @param artifactCache   cache of dependencies (used for id migration from missing file)
      * @param encoding        encoding used to load missing file
@@ -141,8 +158,9 @@ public interface ThirdPartyTool
      * @return the unsafe mapping
      * @throws IOException if pb while reading missing file
      */
-    SortedProperties loadUnsafeMapping( LicenseMap licenseMap, SortedMap<String, MavenProject> artifactCache,
-                                        String encoding, File missingFile, String missingFileUrl )
+    SortedProperties loadUnsafeMapping( MavenProject reactorProject, LicenseMap licenseMap,
+                                        SortedMap<String, MavenProject> artifactCache,
+                                        SortedPropertiesProvider missingLicensesProvider )
             throws IOException, MojoExecutionException;
 
     /**
@@ -155,7 +173,8 @@ public interface ThirdPartyTool
      *                      hoster
      * @throws IOException if pb while reading override file
      */
-    void overrideLicenses( LicenseMap licenseMap, SortedMap<String, MavenProject> artifactCache, String encoding,
+    void overrideLicenses( MavenProject project, LicenseMap licenseMap,
+            SortedMap<String, MavenProject> artifactCache, String encoding,
             String overrideUrl ) throws IOException;
 
     /**

--- a/src/main/java/org/codehaus/mojo/license/api/UnknownDependencyStrategy.java
+++ b/src/main/java/org/codehaus/mojo/license/api/UnknownDependencyStrategy.java
@@ -1,0 +1,39 @@
+package org.codehaus.mojo.license.api;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+/** Do something when we encounter an unknown dependency.
+ *
+ *  <p>One source for unknown dependencies is the <code>missingFileUrl</code>
+ *  configuration option. When a company-wide classpath resource is used
+ *  here, then there will be many projects that don't use all dependencies
+ *  listed.
+ *
+ *  <p>The same is true for the option <code>overrideUrl</code>.
+ *
+ * @since 1.21
+ */
+public interface UnknownDependencyStrategy
+{
+    void handleUnknownDependency( String id );
+}

--- a/src/main/java/org/codehaus/mojo/license/api/UnknownDependencyStrategyFactory.java
+++ b/src/main/java/org/codehaus/mojo/license/api/UnknownDependencyStrategyFactory.java
@@ -1,0 +1,60 @@
+package org.codehaus.mojo.license.api;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.license.api.impl.IgnoreUnknownDependencies;
+import org.codehaus.mojo.license.api.impl.LogUnknownDependencies;
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * Factory for strategies to handle unknown dependencies.
+ *
+ * @since 1.21
+ */
+public class UnknownDependencyStrategyFactory
+{
+    /**
+     * Possible strategies
+     */
+    public static enum Strategy
+    {
+        ignore, warn
+    }
+
+    public UnknownDependencyStrategy build( Strategy strategy, Logger logger, MavenProject project,
+            String configOptionName )
+    {
+        switch ( strategy )
+        {
+        case ignore:
+            return new IgnoreUnknownDependencies();
+
+        case warn:
+            return new LogUnknownDependencies( logger, project, configOptionName );
+
+        default:
+            throw new IllegalArgumentException( "Unsupported strategy: " + strategy );
+        }
+    }
+}

--- a/src/main/java/org/codehaus/mojo/license/api/impl/EmptySortedPropertiesProvider.java
+++ b/src/main/java/org/codehaus/mojo/license/api/impl/EmptySortedPropertiesProvider.java
@@ -1,0 +1,42 @@
+package org.codehaus.mojo.license.api.impl;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.io.IOException;
+
+import org.codehaus.mojo.license.api.SortedPropertiesProvider;
+import org.codehaus.mojo.license.utils.SortedProperties;
+
+/**
+ * Load missing licenses from a URL.
+ *
+ * @since 1.21
+ */
+public class EmptySortedPropertiesProvider implements SortedPropertiesProvider
+{
+    @Override
+    public SortedProperties get() throws IOException
+    {
+        return new SortedProperties( "UTF-8" );
+    }
+}

--- a/src/main/java/org/codehaus/mojo/license/api/impl/IgnoreUnknownDependencies.java
+++ b/src/main/java/org/codehaus/mojo/license/api/impl/IgnoreUnknownDependencies.java
@@ -1,0 +1,39 @@
+package org.codehaus.mojo.license.api.impl;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import org.codehaus.mojo.license.api.UnknownDependencyStrategy;
+
+/**
+ * Ignore unknown dependencies.
+ *
+ * @since 1.21
+ */
+public class IgnoreUnknownDependencies implements UnknownDependencyStrategy
+{
+    @Override
+    public void handleUnknownDependency( String id )
+    {
+        // Do nothing
+    }
+}

--- a/src/main/java/org/codehaus/mojo/license/api/impl/LogUnknownDependencies.java
+++ b/src/main/java/org/codehaus/mojo/license/api/impl/LogUnknownDependencies.java
@@ -1,0 +1,63 @@
+package org.codehaus.mojo.license.api.impl;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import org.apache.maven.project.MavenProject;
+import org.codehaus.mojo.license.api.UnknownDependencyStrategy;
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * Log a warning for unknown dependencies.
+ *
+ * @since 1.21
+ */
+public class LogUnknownDependencies implements UnknownDependencyStrategy
+{
+    private final Logger logger;
+    private final MavenProject project;
+    private final String configOptionName;
+
+    public LogUnknownDependencies( Logger logger,  MavenProject project, String configOptionName )
+    {
+        this.logger = logger;
+        this.project = project;
+        this.configOptionName = configOptionName;
+    }
+
+    @Override
+    public void handleUnknownDependency( String id )
+    {
+        logger.warn( getMessage( id ) );
+    }
+
+    protected String getMessage( String id )
+    {
+        return "Dependency [" + id + "] is mentioned in " + configOptionName
+                + " but isn't used in the project " + getProjectReference();
+    }
+
+    protected String getProjectReference()
+    {
+        return project.getGroupId() + ':' + project.getArtifactId();
+    }
+}

--- a/src/main/java/org/codehaus/mojo/license/api/impl/NoUnsafeMappingsProvider.java
+++ b/src/main/java/org/codehaus/mojo/license/api/impl/NoUnsafeMappingsProvider.java
@@ -1,0 +1,42 @@
+package org.codehaus.mojo.license.api.impl;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.io.IOException;
+
+import org.codehaus.mojo.license.api.SortedPropertiesProvider;
+import org.codehaus.mojo.license.utils.SortedProperties;
+
+/**
+ * Load missing licenses from a URL.
+ *
+ * @since 1.21
+ */
+public class NoUnsafeMappingsProvider implements SortedPropertiesProvider
+{
+    @Override
+    public SortedProperties get() throws IOException
+    {
+        return new SortedProperties( "UTF-8" );
+    }
+}

--- a/src/main/java/org/codehaus/mojo/license/api/impl/SortedPropertiesFileProvider.java
+++ b/src/main/java/org/codehaus/mojo/license/api/impl/SortedPropertiesFileProvider.java
@@ -1,0 +1,62 @@
+package org.codehaus.mojo.license.api.impl;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.io.File;
+import java.io.IOException;
+
+import org.codehaus.mojo.license.api.SortedPropertiesProvider;
+import org.codehaus.mojo.license.utils.SortedProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Load missing licenses from a file.
+ *
+ * @since 1.21
+ */
+public class SortedPropertiesFileProvider implements SortedPropertiesProvider
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger( SortedPropertiesFileProvider.class );
+
+    private final File missingFile;
+    private final String encoding;
+
+    public SortedPropertiesFileProvider( File missingFile, String encoding )
+    {
+        this.missingFile = missingFile.getAbsoluteFile();
+        this.encoding = encoding;
+    }
+
+    @Override
+    public SortedProperties get() throws IOException
+    {
+        SortedProperties result = new SortedProperties( encoding );
+
+        LOGGER.info( "Load missing file {}", missingFile );
+
+        result.load( missingFile );
+
+        return result;
+    }
+}

--- a/src/main/java/org/codehaus/mojo/license/api/impl/SortedPropertiesUrlProvider.java
+++ b/src/main/java/org/codehaus/mojo/license/api/impl/SortedPropertiesUrlProvider.java
@@ -1,0 +1,64 @@
+package org.codehaus.mojo.license.api.impl;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2012 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.codehaus.mojo.license.api.SortedPropertiesProvider;
+import org.codehaus.mojo.license.utils.SortedProperties;
+import org.codehaus.mojo.license.utils.UrlRequester;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Load missing licenses from a URL.
+ *
+ * @since 1.21
+ */
+public class SortedPropertiesUrlProvider implements SortedPropertiesProvider
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger( SortedPropertiesUrlProvider.class );
+
+    private final String missingFileUrl;
+
+    public SortedPropertiesUrlProvider( String missingFileUrl )
+    {
+        this.missingFileUrl = missingFileUrl;
+    }
+
+    @Override
+    public SortedProperties get() throws IOException
+    {
+        String encoding = "UTF-8";
+        SortedProperties result = new SortedProperties( encoding );
+
+        LOGGER.info( "Load missing licenses from URL {}", missingFileUrl );
+
+        String httpRequestResult = UrlRequester.getFromUrl( missingFileUrl );
+        byte[] data = httpRequestResult.getBytes( encoding );
+        result.load( new ByteArrayInputStream( data ) );
+
+        return result;
+    }
+}

--- a/src/test/java/org/codehaus/mojo/license/LicenseMojoUtilsTest.java
+++ b/src/test/java/org/codehaus/mojo/license/LicenseMojoUtilsTest.java
@@ -8,11 +8,13 @@ import org.junit.Test;
 
 public class LicenseMojoUtilsTest
 {
+    public static final File OVERRIDES_PROPERTIES = new File( "src/test/resources/overrides.properties" );
+
     private String resolvedUrl;
     private File deprecatedFile;
     private String url;
     private File basedir = new File( "" );
-    private MockLogger log = new MockLogger();
+    private MockLog log = new MockLog();
 
     @Test
     public void testIsValidNull()
@@ -62,7 +64,7 @@ public class LicenseMojoUtilsTest
     @Test
     public void testPrepareThirdPartyOverrideUrlBothOverrides()
     {
-        deprecatedFile = new File( "src/test/resources/overrides.properties" );
+        deprecatedFile = OVERRIDES_PROPERTIES;
         url = "classpath:overrides.properties";
         try
         {
@@ -93,7 +95,7 @@ public class LicenseMojoUtilsTest
     @Test
     public void testPrepareThirdPartyOverrideUrlDeprecatedFile()
     {
-        deprecatedFile = new File( "src/test/resources/overrides.properties" );
+        deprecatedFile = OVERRIDES_PROPERTIES;
         String actual = runTestAndJoinResults();
         assertEquals(
                 "resolved=file:/.../overrides.properties\n"

--- a/src/test/java/org/codehaus/mojo/license/MockLog.java
+++ b/src/test/java/org/codehaus/mojo/license/MockLog.java
@@ -1,0 +1,178 @@
+package org.codehaus.mojo.license;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.util.StringUtils;
+
+public class MockLog implements Log
+{
+    private boolean debugEnabled = true;
+    private boolean infoEnabled = true;
+    private boolean warnEnabled = true;
+    private boolean errorEnabled = true;
+    private List<String> messages = new ArrayList<>();
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return debugEnabled;
+    }
+
+    @Override
+    public void debug( CharSequence content )
+    {
+        add( debugEnabled, "DEBUG", content );
+    }
+
+    @Override
+    public void debug( CharSequence content, Throwable error )
+    {
+        add( debugEnabled, "DEBUG", content, error );
+    }
+
+    @Override
+    public void debug( Throwable error )
+    {
+        add( debugEnabled, "DEBUG", error );
+    }
+
+    @Override
+    public boolean isInfoEnabled()
+    {
+        return infoEnabled;
+    }
+
+    @Override
+    public void info( CharSequence content )
+    {
+        add( infoEnabled, "INFO", content );
+    }
+
+    @Override
+    public void info( CharSequence content, Throwable error )
+    {
+        add( infoEnabled, "INFO", content, error );
+    }
+
+    @Override
+    public void info( Throwable error )
+    {
+        add( infoEnabled, "INFO", error );
+    }
+
+    @Override
+    public boolean isWarnEnabled()
+    {
+        return warnEnabled;
+    }
+
+    @Override
+    public void warn( CharSequence content )
+    {
+        add( warnEnabled, "WARN", content );
+    }
+
+    @Override
+    public void warn( CharSequence content, Throwable error )
+    {
+        add( warnEnabled, "WARN", content, error );
+    }
+
+    @Override
+    public void warn( Throwable error )
+    {
+        add( warnEnabled, "WARN", error );
+    }
+
+    @Override
+    public boolean isErrorEnabled()
+    {
+        return errorEnabled;
+    }
+
+    @Override
+    public void error( CharSequence content )
+    {
+        add( errorEnabled, "ERROR", content );
+    }
+
+    @Override
+    public void error( CharSequence content, Throwable error )
+    {
+        add( errorEnabled, "ERROR", content, error );
+    }
+
+    @Override
+    public void error( Throwable error )
+    {
+        add( errorEnabled, "ERROR", error );
+    }
+
+    // Builder pattern initialization
+
+    public MockLog enableDebug( boolean enable )
+    {
+        debugEnabled = enable;
+        return this;
+    }
+
+    public MockLog enableInfo( boolean enable )
+    {
+        infoEnabled = enable;
+        return this;
+    }
+
+    public MockLog enableWarn( boolean enable )
+    {
+        warnEnabled = enable;
+        return this;
+    }
+
+    public MockLog enableError( boolean enable )
+    {
+        errorEnabled = enable;
+        return this;
+    }
+
+    private void add(boolean enabled, String level, Throwable error) {
+        add(enabled, level, null, error);
+    }
+
+    private void add(boolean enabled, String level, CharSequence content) {
+        add(enabled, level, content, null);
+    }
+
+    private void add(boolean enabled, String level, CharSequence content, Throwable error) {
+        if (!enabled) {
+            return;
+        }
+
+        StringBuilder buffer = new StringBuilder(level);
+        if (content != null) {
+            buffer.append( ' ' ).append(content);
+        }
+
+        if (error != null) {
+            buffer.append( "\n" ).append(error.toString());
+        }
+
+        messages.add( buffer.toString() );
+    }
+
+    public List<String> getMessages()
+    {
+        return messages;
+    }
+
+    public String dump()
+    {
+        return StringUtils.join( messages.iterator(), "\n" );
+    }
+
+    public void reset()
+    {
+        messages.clear();
+    }
+}

--- a/src/test/java/org/codehaus/mojo/license/api/SortedPropertiesProviderFactoryTest.java
+++ b/src/test/java/org/codehaus/mojo/license/api/SortedPropertiesProviderFactoryTest.java
@@ -1,0 +1,132 @@
+package org.codehaus.mojo.license.api;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.codehaus.mojo.license.LicenseMojoUtilsTest;
+import org.codehaus.mojo.license.api.impl.SortedPropertiesFileProviderTest;
+import org.codehaus.mojo.license.utils.SortedProperties;
+import org.junit.Test;
+
+public class SortedPropertiesProviderFactoryTest {
+
+    private String encoding = "UTF-8";
+
+    @Test
+    public void testNull() throws Exception
+    {
+        SortedProperties actual = new SortedPropertiesProviderFactory( encoding )
+                .build( null, null )
+                .get();
+
+        assertEquals( "{}", actual.toString() );
+    }
+
+    @Test
+    public void testNullModify() throws Exception
+    {
+        SortedPropertiesProvider provider = new SortedPropertiesProviderFactory( encoding )
+                .build( null, null );
+        SortedProperties actual = provider.get();
+
+        assertEquals( "{}", actual.toString() );
+
+        actual.setProperty( "foo", "bar" );
+        assertEquals( "{foo=bar}", actual.toString() );
+
+        SortedProperties another = provider.get();
+        assertEquals( "{}", another.toString() );
+    }
+
+    @Test
+    public void testFile() throws Exception
+    {
+        File file = LicenseMojoUtilsTest.OVERRIDES_PROPERTIES;
+        SortedProperties actual = new SortedPropertiesProviderFactory( encoding )
+            .build( file, null )
+            .get();
+
+        assertEquals( SortedPropertiesFileProviderTest.EXPECTED_OVERRIDES, actual.toString() );
+
+        // TODO Port RedirectLogger
+//        String log = logger.dump()
+//                .replace( file.getAbsolutePath(), "/.../" + file.getName() );
+//        assertEquals( "INFO Load missing file /.../overrides.properties", log );
+    }
+
+    @Test
+    public void testNoSuchFile() throws Exception
+    {
+        File file = new File( "foo" );
+        SortedProperties actual = new SortedPropertiesProviderFactory( encoding )
+                .build( file, null )
+                .get();
+
+        assertEquals( "{}", actual.toString() );
+
+        // TODO Port RedirectLogger
+//        String log = logger.dump()
+//                .replace( file.getAbsolutePath(), "/.../" + file.getName() );
+//        assertEquals( "DEBUG No such file: /.../foo", log );
+    }
+
+    @Test
+    public void testUrl() throws Exception
+    {
+        String url = "classpath:overrides.properties";
+        SortedProperties actual = new SortedPropertiesProviderFactory( encoding )
+            .build( null, url)
+            .get();
+
+        assertEquals( SortedPropertiesFileProviderTest.EXPECTED_OVERRIDES, actual.toString() );
+
+        // TODO Port RedirectLogger
+//        String log = logger.dump();
+//        assertEquals( "INFO Load missing licenses from URL classpath:overrides.properties", log );
+    }
+
+    @Test
+    public void testNoSuchUrl() throws Exception
+    {
+        String url = "classpath:doesntexist.properties";
+        SortedPropertiesProvider provider = new SortedPropertiesProviderFactory( encoding )
+                .build( null, url);
+
+        try
+        {
+            provider.get();
+
+            fail( "Missing exception" );
+        }
+        catch( IOException e )
+        {
+            assertEquals( "The resource doesntexist.properties was not found in the maven plugin classpath",
+                    e.getMessage() );
+        }
+    }
+
+    /**
+     * Test which one is preferred: File or URL?
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testFileAndUrl() throws Exception
+    {
+        File file = LicenseMojoUtilsTest.OVERRIDES_PROPERTIES;
+        String url = "classpath:overrides.properties";
+        SortedProperties actual = new SortedPropertiesProviderFactory( encoding )
+                .build( file, url )
+                .get();
+
+        assertEquals( SortedPropertiesFileProviderTest.EXPECTED_OVERRIDES, actual.toString() );
+
+        // TODO Port RedirectLogger
+//        String log = logger.dump()
+//                .replace( file.getAbsolutePath(), "/.../" + file.getName() );
+//        assertEquals( "INFO Load missing file /.../overrides.properties", log );
+    }
+
+}

--- a/src/test/java/org/codehaus/mojo/license/api/impl/SortedPropertiesFileProviderTest.java
+++ b/src/test/java/org/codehaus/mojo/license/api/impl/SortedPropertiesFileProviderTest.java
@@ -1,0 +1,24 @@
+package org.codehaus.mojo.license.api.impl;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.codehaus.mojo.license.LicenseMojoUtilsTest;
+import org.codehaus.mojo.license.utils.SortedProperties;
+import org.junit.Test;
+
+public class SortedPropertiesFileProviderTest {
+
+    public static final String EXPECTED_OVERRIDES =
+            "{org.jboss.xnio--xnio-api--3.3.6.Final=The Apache Software License, Version 2.0}";
+
+    @Test
+    public void testFile() throws Exception
+    {
+        File file = LicenseMojoUtilsTest.OVERRIDES_PROPERTIES;
+        SortedProperties actual = new SortedPropertiesFileProvider( file, "UTF-8" )
+                .get();
+        assertEquals( EXPECTED_OVERRIDES, actual.toString() );
+    }
+}

--- a/src/test/java/org/codehaus/mojo/license/api/impl/SortedPropertiesUrlProviderTest.java
+++ b/src/test/java/org/codehaus/mojo/license/api/impl/SortedPropertiesUrlProviderTest.java
@@ -1,0 +1,18 @@
+package org.codehaus.mojo.license.api.impl;
+
+import static org.junit.Assert.*;
+
+import org.codehaus.mojo.license.utils.SortedProperties;
+import org.junit.Test;
+
+public class SortedPropertiesUrlProviderTest {
+
+    @Test
+    public void testUrl() throws Exception
+    {
+        String url = "classpath:overrides.properties";
+        SortedProperties actual = new SortedPropertiesUrlProvider( url )
+                .get();
+        assertEquals( SortedPropertiesFileProviderTest.EXPECTED_OVERRIDES, actual.toString() );
+    }
+}

--- a/src/test/java/org/codehaus/mojo/license/download/LicenseMatchersTest.java
+++ b/src/test/java/org/codehaus/mojo/license/download/LicenseMatchersTest.java
@@ -22,7 +22,6 @@ package org.codehaus.mojo.license.download;
  * #L%
  */
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.codehaus.mojo.license.download.LicenseMatchers.DependencyMatcher;

--- a/src/test/resources/overrides2.properties
+++ b/src/test/resources/overrides2.properties
@@ -1,0 +1,1 @@
+org.jboss.xnio--xnio-api--3.3.6.Final=The Apache Software License, Version 2.0


### PR DESCRIPTION
First attempt to make logging of unknown dependencies configurable.
This is way too much code but I had to introduce new objects or checkstyle would fail the build (too many parameters per method).
Also, I couldn't use plexus loggers and had to switch to slf4j instead because in the Mojo, I can't get a plexus logger. And in other parts, I can only call getLog() which is another beast. Logging is a mess.