### PR TITLE
Update the CDDLv1 license header

### DIFF
--- a/src/main/resources/META-INF/licenses/cddl_v1/header.txt
+++ b/src/main/resources/META-INF/licenses/cddl_v1/header.txt
@@ -1,15 +1,9 @@
-COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the Common Development and Distrubtion License as
-published by the Sun Microsystems, either version 1.0 of the
-License, or (at your option) any later version.
+You can obtain a copy of the License at
+https://opensource.org/licenses/CDDL-1.0.
+See the License for the specific language governing permissions
+and limitations under the License.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Lesser Public License for more details.
-
-You should have received a copy of the Common Development and Distrubtion
-License along with this program.  If not, see
-<http://www.gnu.org/licenses/gpl-1.0.html>.


### PR DESCRIPTION
The CDDL v1.0 license header contained a wrong URL and several typos.

[edit]
We could also use the SPDX URL: https://spdx.org/licenses/CDDL-1.0.html