### PR TITLE
Fix #139 - "Can't find license-maven-plugin"

### DIFF
--- a/src/it/add-third-party-no-encoding/invoker.properties
+++ b/src/it/add-third-party-no-encoding/invoker.properties
@@ -19,5 +19,5 @@
 # <http://www.gnu.org/licenses/lgpl-3.0.html>.
 # #L%
 ###
-invoker.goals=clean license:add-third-party
+invoker.goals=clean ${project.groupId}:${project.artifactId}:${project.version}:add-third-party
 invoker.failureBehavior=fail-fast

--- a/src/it/add-third-party-no-encoding/pom.xml
+++ b/src/it/add-third-party-no-encoding/pom.xml
@@ -45,19 +45,6 @@
       <version>1.1.1</version>
     </dependency>
   </dependencies>
-  <build>
-
-    <pluginManagement>
-      <plugins>
-
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>license-maven-plugin</artifactId>
-          <version>@pom.version@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 
 </project>
 

--- a/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AggregatorAddThirdPartyMojo.java
@@ -33,6 +33,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -203,10 +204,29 @@ public class AggregatorAddThirdPartyMojo extends AbstractAddThirdPartyMojo
         }
         if ( groupId == null )
         {
-            throw new IllegalStateException( "Can't find license-maven-plugin" );
+            try
+            {
+                final PluginDescriptor pd = ( PluginDescriptor ) getPluginContext().get( "pluginDescriptor" );
+                groupId = pd.getGroupId();
+                artifactId = pd.getArtifactId();
+                version = pd.getVersion();
+            }
+            catch ( ClassCastException e )
+            {
+                LOG.warn( "Failed to access PluginDescriptor", e );
+            }
+
+            if ( groupId == null )
+            {
+                throw new IllegalStateException( "Failed to determine the license-maven-plugin artifact."
+                    +
+                    "Please add it to your parent POM." );
+            }
         }
 
         String addThirdPartyRoleHint = groupId + ":" + artifactId + ":" + version + ":" + "add-third-party";
+
+        LOG.info( "The default plugin hint is: " + addThirdPartyRoleHint );
 
         for ( MavenProject reactorProject : reactorProjects )
         {


### PR DESCRIPTION
Use the PluginDescriptor.
Most painful checkstyle.