### PR TITLE
fix copy&paste issue in property description

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
@@ -201,7 +201,7 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo
     private boolean emptyLineAfterHeader;
 
     /**
-     * A flag to indicate if there should be an empty line after the header.
+     * A flag to indicate if trailing spaces should be trimmed.
      * <p>
      * Checkstyle usually requires no trailing whitespace.
      * If it is the case it could make sense to set this to true


### PR DESCRIPTION
This change corrects the description for `trimHeaderLine`.