### PR TITLE
Handle lineSeparator conversion with tokens LF / CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-*        text eol=lf
-*.cmd    text eol=crlf
+*         text eol=lf
+*.cmd     text eol=crlf
+CrLf.java text eol=crlf
+Lf.java   text eol=lf

--- a/src/it/update-line-separator-test-mojo/LICENSE.txt
+++ b/src/it/update-line-separator-test-mojo/LICENSE.txt
@@ -1,0 +1,166 @@
+		   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.
+

--- a/src/it/update-line-separator-test-mojo/invoker.properties
+++ b/src/it/update-line-separator-test-mojo/invoker.properties
@@ -1,0 +1,23 @@
+###
+# #%L
+# License Maven Plugin
+# %%
+# Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+# %%
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Lesser Public License for more details.
+#
+# You should have received a copy of the GNU General Lesser Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/lgpl-3.0.html>.
+# #L%
+###
+invoker.goals=clean compile
+invoker.failureBehavior=fail-fast

--- a/src/it/update-line-separator-test-mojo/pom.xml
+++ b/src/it/update-line-separator-test-mojo/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license.test</groupId>
+  <artifactId>update-file-header-test-mojo</artifactId>
+  <version>@project.version@</version>
+
+  <name>License Test :: update-file-header-specific</name>
+
+  <inceptionYear>2012</inceptionYear>
+
+  <organization>
+    <name>License Test</name>
+  </organization>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <packaging>pom</packaging>
+
+  <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>@project.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <verbose>true</verbose>
+          <addSvnKeyWords>true</addSvnKeyWords>
+        </configuration>
+        <executions>
+          <execution>
+            <id>update-line-separator-test-crlf</id>
+            <goals>
+              <goal>update-file-header</goal>
+            </goals>
+            <phase>process-sources</phase>
+            <configuration>
+              <licenseName>gpl_v3</licenseName>
+              <roots>
+                <param>src/main/java/crlf</param>
+              </roots>
+              <lineSeparator>CRLF</lineSeparator>
+            </configuration>
+          </execution>
+          <execution>
+            <id>update-line-separator-test-lf</id>
+            <goals>
+              <goal>update-file-header</goal>
+            </goals>
+            <phase>process-sources</phase>
+            <configuration>
+              <licenseName>gpl_v3</licenseName>
+              <roots>
+                <param>src/main/java/lf</param>
+              </roots>
+              <lineSeparator>LF</lineSeparator>
+            </configuration>
+          </execution>
+          <execution>
+            <id>update-line-separator-test-str</id>
+            <goals>
+              <goal>update-file-header</goal>
+            </goals>
+            <phase>process-sources</phase>
+            <configuration>
+              <licenseName>gpl_v3</licenseName>
+              <roots>
+                <param>src/main/java/str</param>
+              </roots>
+              <lineSeparator>STR</lineSeparator>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
+
+

--- a/src/it/update-line-separator-test-mojo/postbuild.groovy
+++ b/src/it/update-line-separator-test-mojo/postbuild.groovy
@@ -1,0 +1,125 @@
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+def assertExistsDirectory(file)
+{
+  if ( !file.exists() || !file.isDirectory() )
+  {
+    println(file.getAbsolutePath() + " file is missing or is not a directory.")
+    assert false
+  }
+  assert true
+}
+
+def assertExistsFile(file)
+{
+  if ( !file.exists() || file.isDirectory() )
+  {
+    println(file.getAbsolutePath() + " file is missing or a directory.")
+    assert false
+  }
+  assert true
+}
+
+def assertContains(file, content, expected)
+{
+  if ( !content.contains(expected) )
+  {
+    println(expected + " was not found in file [" + file + "]\n :" + content)
+    return false
+  }
+  return true
+}
+
+def assertNotContains(file, content, expected)
+{
+  if ( content.contains(expected) )
+  {
+    println(expected + " should not be found in file [" + file + "]\n :" + content)
+    return false
+  }
+  return true
+}
+
+//def newLine = System.getProperty("line.separator")
+
+Calendar cal = Calendar.getInstance();
+cal.setTime(new Date());
+int currentYear = cal.get(Calendar.YEAR);
+dateRange = "2012";
+if ( currentYear > 2012 )
+{
+  dateRange += " - " + currentYear;
+}
+println("Current year: " + currentYear)
+println("Date range to use: " + dateRange)
+
+//
+// TEST CRLF
+//
+
+file = new File(basedir, 'src/main/java/crlf/org/codehaus/mojo/license/Lf.java');
+assertExistsFile(file);
+
+content = file.text;
+assert assertContains(file, content, 'Copyright (C) 2010 Tony\r\n');
+
+file = new File(basedir, 'src/main/java/crlf/org/codehaus/mojo/license/CrLf.java');
+assertExistsFile(file);
+
+content = file.text;
+assert assertContains(file, content, 'Copyright (C) 2010 Tony\r\n');
+
+//
+// TEST LF
+//
+
+file = new File(basedir, 'src/main/java/lf/org/codehaus/mojo/license/Lf.java');
+assertExistsFile(file);
+
+content = file.text;
+assert assertContains(file, content, 'Copyright (C) 2010 Tony\n');
+
+file = new File(basedir, 'src/main/java/lf/org/codehaus/mojo/license/CrLf.java');
+assertExistsFile(file);
+
+content = file.text;
+assert assertContains(file, content, 'Copyright (C) 2010 Tony\n');
+
+//
+// TEST CRLF
+//
+
+file = new File(basedir, 'src/main/java/str/org/codehaus/mojo/license/Lf.java');
+assertExistsFile(file);
+
+content = file.text;
+assert assertContains(file, content, 'Copyright (C) 2010 TonySTR');
+
+file = new File(basedir, 'src/main/java/crlf/org/codehaus/mojo/license/CrLf.java');
+assertExistsFile(file);
+
+content = file.text;
+assert assertContains(file, content, 'Copyright (C) 2010 TonySTR');
+
+
+return true;

--- a/src/it/update-line-separator-test-mojo/src/main/java/crlf/org/codehaus/mojo/license/CrLf.java
+++ b/src/it/update-line-separator-test-mojo/src/main/java/crlf/org/codehaus/mojo/license/CrLf.java
@@ -1,0 +1,21 @@
+/*
+ * #%L
+ * License Test :: do NOT update!
+ * %%
+ * Copyright (C) 2010 Tony
+ * %%
+ * Fake to be removed!
+ * #L%
+ */
+
+/**
+ * this class owns a header, only license will be updated.
+ *
+ * @author tchemit dev@tchemit.fr
+ * @since 1.0
+ */
+package org.codehaus.mojo.license;
+
+public class Lf
+{
+}

--- a/src/it/update-line-separator-test-mojo/src/main/java/crlf/org/codehaus/mojo/license/Lf.java
+++ b/src/it/update-line-separator-test-mojo/src/main/java/crlf/org/codehaus/mojo/license/Lf.java
@@ -1,0 +1,21 @@
+/*
+ * #%L
+ * License Test :: do NOT update!
+ * %%
+ * Copyright (C) 2010 Tony
+ * %%
+ * Fake to be removed!
+ * #L%
+ */
+
+/**
+ * this class owns a header, only license will be updated.
+ *
+ * @author tchemit dev@tchemit.fr
+ * @since 1.0
+ */
+package org.codehaus.mojo.license;
+
+public class Lf
+{
+}

--- a/src/it/update-line-separator-test-mojo/src/main/java/lf/org/codehaus/mojo/license/CrLf.java
+++ b/src/it/update-line-separator-test-mojo/src/main/java/lf/org/codehaus/mojo/license/CrLf.java
@@ -1,0 +1,21 @@
+/*
+ * #%L
+ * License Test :: do NOT update!
+ * %%
+ * Copyright (C) 2010 Tony
+ * %%
+ * Fake to be removed!
+ * #L%
+ */
+
+/**
+ * this class owns a header, only license will be updated.
+ *
+ * @author tchemit dev@tchemit.fr
+ * @since 1.0
+ */
+package org.codehaus.mojo.license;
+
+public class Lf
+{
+}

--- a/src/it/update-line-separator-test-mojo/src/main/java/lf/org/codehaus/mojo/license/Lf.java
+++ b/src/it/update-line-separator-test-mojo/src/main/java/lf/org/codehaus/mojo/license/Lf.java
@@ -1,0 +1,21 @@
+/*
+ * #%L
+ * License Test :: do NOT update!
+ * %%
+ * Copyright (C) 2010 Tony
+ * %%
+ * Fake to be removed!
+ * #L%
+ */
+
+/**
+ * this class owns a header, only license will be updated.
+ *
+ * @author tchemit dev@tchemit.fr
+ * @since 1.0
+ */
+package org.codehaus.mojo.license;
+
+public class Lf
+{
+}

--- a/src/it/update-line-separator-test-mojo/src/main/java/str/org/codehaus/mojo/license/CrLf.java
+++ b/src/it/update-line-separator-test-mojo/src/main/java/str/org/codehaus/mojo/license/CrLf.java
@@ -1,0 +1,21 @@
+/*
+ * #%L
+ * License Test :: do NOT update!
+ * %%
+ * Copyright (C) 2010 Tony
+ * %%
+ * Fake to be removed!
+ * #L%
+ */
+
+/**
+ * this class owns a header, only license will be updated.
+ *
+ * @author tchemit dev@tchemit.fr
+ * @since 1.0
+ */
+package org.codehaus.mojo.license;
+
+public class Lf
+{
+}

--- a/src/it/update-line-separator-test-mojo/src/main/java/str/org/codehaus/mojo/license/Lf.java
+++ b/src/it/update-line-separator-test-mojo/src/main/java/str/org/codehaus/mojo/license/Lf.java
@@ -1,0 +1,21 @@
+/*
+ * #%L
+ * License Test :: do NOT update!
+ * %%
+ * Copyright (C) 2010 Tony
+ * %%
+ * Fake to be removed!
+ * #L%
+ */
+
+/**
+ * this class owns a header, only license will be updated.
+ *
+ * @author tchemit dev@tchemit.fr
+ * @since 1.0
+ */
+package org.codehaus.mojo.license;
+
+public class Lf
+{
+}

--- a/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
@@ -488,6 +488,15 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo {
         if (isVerbose()) {
             LOG.info("Will use sectionDelimiter: {}", sectionDelimiter);
         }
+        if (isVerbose()) {
+            String verboseLineSeparator;
+            try {
+                verboseLineSeparator = Eol.from(lineSeparator).name();
+            } catch (IllegalArgumentException e) {
+                verboseLineSeparator = lineSeparator;
+            }
+            LOG.info("Will use lineSeparator: {}", verboseLineSeparator);
+        }
 
         // add default extensions from header transformers
         for (Map.Entry<String, FileHeaderTransformer> entry : transformers.entrySet()) {

--- a/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
@@ -100,7 +100,8 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo {
     private String sectionDelimiter;
 
     /**
-     * To specify a line separator to use.
+     * To specify a line separator to use. Providing "LF" and "CRLF" will instead use the characters "\n" and "\r\n",
+     * respectively.
      *
      * If not set, will use system property {@code line.separator}.
      */

--- a/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractFileHeaderMojo.java
@@ -403,6 +403,20 @@ public abstract class AbstractFileHeaderMojo extends AbstractLicenseNameMojo {
      */
     protected abstract boolean isFailOnNotUptodateHeader();
 
+    /**
+     * Converts line ending string, like LF or CRLF, to proper line separator character.
+     *
+     * @param lineSeparator Line separator that may be converted.
+     */
+    public void setLineSeparator(String lineSeparator) {
+        try {
+            this.lineSeparator = Eol.valueOf(lineSeparator).getEolString();
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Unable to parse lineSeparator '{}', using it as-is.", lineSeparator);
+            this.lineSeparator = lineSeparator;
+        }
+    }
+
     // ----------------------------------------------------------------------
     // AbstractLicenseMojo Implementaton
     // ----------------------------------------------------------------------

--- a/src/main/java/org/codehaus/mojo/license/Eol.java
+++ b/src/main/java/org/codehaus/mojo/license/Eol.java
@@ -74,4 +74,18 @@ public enum Eol {
     public String getEolString() {
         return eolString;
     }
+
+    public static Eol from(String eol) throws IllegalArgumentException {
+        switch (eol) {
+            case "\r\n":
+                return CRLF;
+            case "\n":
+                return LF;
+            default:
+                throw new IllegalArgumentException(String.format(
+                    "Unable to convert Eol from %s",
+                    eol
+                ));
+        }
+    }
 }

--- a/src/main/java/org/codehaus/mojo/license/Eol.java
+++ b/src/main/java/org/codehaus/mojo/license/Eol.java
@@ -82,10 +82,7 @@ public enum Eol {
             case "\n":
                 return LF;
             default:
-                throw new IllegalArgumentException(String.format(
-                    "Unable to convert Eol from %s",
-                    eol
-                ));
+                throw new IllegalArgumentException(String.format("Unable to convert Eol from %s", eol));
         }
     }
 }

--- a/src/site/apt/examples/update-file-header-config.apt.vm
+++ b/src/site/apt/examples/update-file-header-config.apt.vm
@@ -41,6 +41,9 @@ Update File Header Examples
 
     * customize description section: Define a template to change the description section of a file header.
 
+    * lineSeparator: Use a custom chain of character as line separator. Providing "LF" and "CRLF" will instead use the
+    characters "\n" and "\r\n", respectively.
+
   To see all extensions accepted run the <<comment-style-list>> goal.
 
 -------------------------------------------------------------------------------

--- a/src/site/apt/examples/update-file-header-config.apt.vm
+++ b/src/site/apt/examples/update-file-header-config.apt.vm
@@ -41,8 +41,8 @@ Update File Header Examples
 
     * customize description section: Define a template to change the description section of a file header.
 
-    * lineSeparator: Use a custom chain of character as line separator. Providing "LF" and "CRLF" will instead use the
-    characters "\n" and "\r\n", respectively.
+    * lineSeparator: To specify a line separator to use. Providing "LF" and "CRLF" will instead use the characters "\n"
+    and "\r\n", respectively.
 
   To see all extensions accepted run the <<comment-style-list>> goal.
 


### PR DESCRIPTION
This PR is linked to my comment on the issue #106 

We are now able to provide the lineSeparator information with :

```xml
<license.lineSeparator>LF</license.lineSeparator>
<license.lineSeparator>CRLF</license.lineSeparator>
```

I tried to do the smallest change possible to avoid breaking anything, I'm not sure that it fits the codebase as I've not spent much time looking into the project.