### PR TITLE
Fix build failure by configuring and upgrading editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,5 @@ end_of_line = lf
 [*.xml]
 indent_size = 2
 
-[*.cmd]
+[{*.cmd, *.crlf.sh}]
 end_of_line = crlf

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
         <plugin>
           <groupId>org.ec4j.maven</groupId>
           <artifactId>editorconfig-maven-plugin</artifactId>
-          <version>0.0.10</version>
+          <version>0.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.gmaven</groupId>

--- a/src/it/update-file-header-test-mojo/src/files/properties/.editorconfig
+++ b/src/it/update-file-header-test-mojo/src/files/properties/.editorconfig
@@ -1,2 +1,0 @@
-[*.crlf.sh]
-end_of_line = crlf


### PR DESCRIPTION
Running `mvn clean package` on master branch gives errors:
```
[ERROR] src/it/update-file-header-test-mojo/src/files/properties/test.crlf.sh@1,10: Insert cr - violates end_of_line = crlf, reported by org.ec4j.linters.TextLinter
[ERROR] src/it/update-file-header-test-mojo/src/files/properties/test.crlf.sh@2,1: Insert cr - violates end_of_line = crlf, reported by org.ec4j.linters.TextLinter
```
For some reasons the file https://github.com/mojohaus/license-maven-plugin/blob/master/src/it/update-file-header-test-mojo/src/files/properties/.editorconfig is not taken into account.

In this commit:
- Remove the .editorconfig file in /src/it/update-file-header-test-mojo/src/files/properties
- Added its rule in the main .editorconfig
- Upgrade editorconfig-maven-plugin from 0.0.10 to 0.1.1

The master branch now builds.