### PR TITLE
Fix IT test download-licenses-file-names

### DIFF
--- a/src/it/download-licenses-file-names/licenses-basic.expected.xml
+++ b/src/it/download-licenses-file-names/licenses-basic.expected.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.3</version>
+      <version>1.9.4</version>
       <licenses>
         <license>
           <name>Apache License, Version 2.0</name>

--- a/src/it/download-licenses-file-names/licenses-spdx.expected.xml
+++ b/src/it/download-licenses-file-names/licenses-spdx.expected.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.3</version>
+      <version>1.9.4</version>
       <licenses>
         <license>
           <name>Apache License, Version 2.0</name>

--- a/src/it/download-licenses-file-names/pom.xml
+++ b/src/it/download-licenses-file-names/pom.xml
@@ -88,7 +88,7 @@
               </licenseUrlReplacements>
               <licenseUrlFileNames>
                 <bsd-antlr.html>
-                    sha1:074f8d6e91730b40875178666513014472888247
+                    sha1:666518759e606772587886dcb54a9867bcf275e0
                     \Qhttp://www.antlr.org/license.html\E
                 </bsd-antlr.html>
                 <asl2.txt>
@@ -123,7 +123,7 @@
               <licenseUrlFileNames>
                 <spdx/>
                 <bsd-antlr.html>
-                    sha1:074f8d6e91730b40875178666513014472888247
+                    sha1:666518759e606772587886dcb54a9867bcf275e0
                     \Qhttp://www.antlr.org/license.html\E
                 </bsd-antlr.html>
                 <cddl-gplv2-ce.txt>


### PR DESCRIPTION
Dependabot on commit https://github.com/mojohaus/license-maven-plugin/commit/6d2b028b1f00e0ddbf03ad4ab9a3d9a7c9684773 bumps commons-beanutils from 1.9.3 to 1.9.4.

This breaks the IT test download-licenses-file-names.

This commit updates the files licenses-basic.expected.xml and licenses-spdx.expected.xml files with the new commons-beanutils version. It update also the bsd-antlr.html SHA1 in /src/it/download-licenses-file-names/pom.xml.

The IT test add-third-party-excluded-included now succeed.

The test can be run with:

````
mvn org.apache.maven.plugins:maven-invoker-plugin:3.0.0:integration-test -Dinvoker.test=download-licenses-file-names
`````
