### PR TITLE
Fix IT test download-licenses-basic

### DIFF
--- a/src/it/download-licenses-basic/expected_licenses_ordering_1.xml
+++ b/src/it/download-licenses-basic/expected_licenses_ordering_1.xml
@@ -4,7 +4,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <licenses>
         <license>
           <name>Eclipse Public License 1.0</name>

--- a/src/it/download-licenses-basic/expected_licenses_ordering_2.xml
+++ b/src/it/download-licenses-basic/expected_licenses_ordering_2.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <licenses>
         <license>
           <name>Eclipse Public License 1.0</name>


### PR DESCRIPTION
Dependabot on commit https://github.com/mojohaus/license-maven-plugin/commit/7b3eb3d07ccad42edfed34355d30903889716857 bumps JUnit to 4.13.1.

This breaks IT test download-licenses-basic because it relies on the exact version of JUnit.

This commit bumps the JUnit version in expected_licenses_ordering_1.xml and expected_licenses_ordering_2.xml files. The IT test download-licenses-basic now succeed.

The test can be run with:

mvn org.apache.maven.plugins:maven-invoker-plugin:3.0.0:integration-test -Dinvoker.test=download-licenses-basic