### PR TITLE
Fix two IT tests aggregate-add-third-party-*

### DIFF
--- a/src/it/aggregate-add-third-party-exclude-transitive-deps/postbuild.groovy
+++ b/src/it/aggregate-add-third-party-exclude-transitive-deps/postbuild.groovy
@@ -32,6 +32,6 @@ assert !content.contains('org.nuiton.i18n:nuiton-i18n:1.2.2');
 assert !content.contains('junit:junit:3.8.1');
 
 assert content.contains('org.nuiton:maven-helper-plugin:1.2.3');
-assert content.contains('junit:junit:4.8.1');
+assert content.contains('junit:junit:4.13.1');
 
 return true

--- a/src/it/aggregate-add-third-party-simple/postbuild.groovy
+++ b/src/it/aggregate-add-third-party-simple/postbuild.groovy
@@ -24,14 +24,14 @@ file = new File(basedir, 'target/generated-sources/license/THIRD-PARTY.txt');
 assert file.exists();
 content = file.text;
 assert !content.contains('the project has no dependencies.');
-assert content.contains('(Common Public License Version 1.0) JUnit (junit:junit:4.8.1 - http://junit.org)');
+assert content.contains('(Eclipse Public License 1.0) JUnit (junit:junit:4.13.1 - http://junit.org)');
 assert content.contains('(The Apache Software License, Version 2.0) Commons Logging (commons-logging:commons-logging:1.1.1 - http://commons.apache.org/logging)');
 
 file = new File(basedir, 'target/generated-sources/license/META-INF/test-aggregate-add-third-party-THIRD-PARTY.txt');
 assert file.exists();
 content = file.text;
 assert !content.contains('the project has no dependencies.');
-assert content.contains('(Common Public License Version 1.0) JUnit (junit:junit:4.8.1 - http://junit.org)');
+assert content.contains('(Eclipse Public License 1.0) JUnit (junit:junit:4.13.1 - http://junit.org)');
 assert content.contains('(The Apache Software License, Version 2.0) Commons Logging (commons-logging:commons-logging:1.1.1 - http://commons.apache.org/logging)');
 
 file = new File(basedir, 'child1/target/generated-sources/license/THIRD-PARTY.txt');


### PR DESCRIPTION
- In the IT test aggregate-add-third-party-exclude-transitive-deps, the JUnit version is no more correct.
- In the IT test aggregate-add-third-party-simple, the Junit version and the license are no more correct.

Fix them in:
- src/it/aggregate-add-third-party-exclude-transitive-deps/postbuild.groovy
- src/it/aggregate-add-third-party-simple/postbuild.groovy