### PR TITLE
Recognize classpath protocol as external

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
+++ b/src/main/java/org/codehaus/mojo/license/api/DefaultThirdPartyTool.java
@@ -610,6 +610,9 @@ public class DefaultThirdPartyTool
             {
                 overrideMappings.load( reader );
             }
+
+            boolean isExternalUrl = UrlRequester.isExternalUrl(overrideUrl);
+
             for ( Object o : overrideMappings.keySet() )
             {
                 String id = (String) o;
@@ -618,8 +621,7 @@ public class DefaultThirdPartyTool
                 if ( project == null )
                 {
                     // Log at warn for local override files, but at debug for remote (presumably shared) override files.
-                    String protocol = UrlRequester.findProtocol( overrideUrl );
-                    if ( "http".equals( protocol ) || "https".equals( protocol ) )
+                    if ( isExternalUrl )
                     {
                         LOG.debug( "dependency [{}] does not exist in project.", id );
                     }

--- a/src/main/java/org/codehaus/mojo/license/utils/UrlRequester.java
+++ b/src/main/java/org/codehaus/mojo/license/utils/UrlRequester.java
@@ -79,6 +79,18 @@ public class UrlRequester
     }
 
     /**
+     * Check if URL point to external resource.
+     *
+     * @param url the URL as a string
+     * @return true if URL use external protocol
+     */
+    public static boolean isExternalUrl( String url )
+    {
+        String protocol = findProtocol( url );
+        return "http".equals( protocol ) || "https".equals( protocol ) || CLASSPATH_PROTOCOL.equals( protocol );
+    }
+
+    /**
      * Returns the content of the resource pointed by the given URL as a string.
      *
      * @param url the resource destination that is expected to contain pure text

--- a/src/test/java/org/codehaus/mojo/license/utils/UrlRequesterTest.java
+++ b/src/test/java/org/codehaus/mojo/license/utils/UrlRequesterTest.java
@@ -43,4 +43,10 @@ public class UrlRequesterTest
         Assert.assertTrue( "classpath protocol not registered", UrlRequester.isStringUrl( "classpath:" + RESOURCE_NAME ) );
     }
 
+    @Test
+    public void testClasspathIsAExternalUrl()
+    {
+        Assert.assertTrue( "classpath protocol as external", UrlRequester.isExternalUrl( "classpath:" + RESOURCE_NAME ) );
+    }
+
 }


### PR DESCRIPTION
Resources from classpath should be recognized as external resources - can be used as shared