### PR TITLE
Log message about skip due to packaging in info level

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractLicenseMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractLicenseMojo.java
@@ -158,7 +158,7 @@ public abstract class AbstractLicenseMojo
             boolean canContinue = checkPackaging();
             if ( !canContinue )
             {
-                LOG.warn( "The goal is skip due to packaging '{}'", getProject().getPackaging() );
+                LOG.info( "The goal is skip due to packaging '{}'", getProject().getPackaging() );
                 return;
             }
 


### PR DESCRIPTION
There is no error if plugin is skipped for specified packaging.
Similar message about skip at all is also logged in info level.