### PR TITLE
Downgrade plexus-xml to version 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
-      <version>4.0.2</version>
+      <version>3.0.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Version 4.x is dedicated for Maven 4.x