### PR TITLE
Fix  issue #560: fail to download license file because license name contains invalid characters

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -1233,8 +1233,8 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
             licenseFileName = licenseFileName.replaceAll("\\s+", " ");
         }
 
-        // lower case and (back)slash removal
-        licenseFileName = licenseFileName.toLowerCase(Locale.US).replaceAll("[\\\\/]+", "_");
+        // lower case and invalid filename characters removal
+        licenseFileName = licenseFileName.toLowerCase(Locale.US).replaceAll("[\\\\/:*?\"<>|]+", "_");
 
         licenseFileName = sanitize(licenseFileName);
 


### PR DESCRIPTION
Hi, 
As I have mentioned in the issue #560, currently some license file name contains illegal character in name which leads to fail to download license file from remote URL. I check the code and see there's already a regex to remove back slashes, but we need more than that. So I just added couple more illegal characters known as illegal.
I was built and tested on my project and the maven goal worked as expected.
 
Before:
```
[DEBUG] Downloading license(s) for project com.github.oshi:oshi-core-java11
[DEBUG] About to download 'https://opensource.org/licenses/MIT'
[DEBUG] Downloading 'https://opensource.org/licenses/MIT' -> 'C:\Users\username\git\projectx\target\generated-resources\licenses\spdx-license-identifier: mit - mit.html'
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  20.418 s
[INFO] Finished at: 2024-04-17T15:44:45+07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:license-maven-plugin:2.4.0:download-licenses (default-cli) on project projectx: Execution default-cli of goal org.codehaus.mojo:license-maven-plugin:2.4.0:download-licenses failed: Illegal char <:> at index 135: C:\Users\username\git\projectx\target\generated-resources\licenses\spdx-license-identifier: mit - mit.html -> [Help 1]
```

After:
```
[DEBUG] About to download 'https://opensource.org/licenses/MIT'
[DEBUG] Downloading 'https://opensource.org/licenses/MIT' -> 'C:\Users\username\git\projectx\target\generated-resources\licenses\spdx-license-identifier_ mit - mit.html'
[DEBUG] Downloading license(s) for project com.google.auto:auto-common
[DEBUG] Downloading license(s) for project com.google.auto.service:auto-service
[DEBUG] Downloading license(s) for project com.google.auto.service:auto-service-annotations
[DEBUG] Downloading license(s) for project com.google.code.findbugs:jsr305
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33.197 s
[INFO] Finished at: 2024-04-17T15:34:08+07:00

```