### PR TITLE
Parallel processing of files

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractLicenseNameMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractLicenseNameMojo.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -388,7 +387,7 @@ public abstract class AbstractLicenseNameMojo extends AbstractLicenseMojo {
      * @param state  state of file to report
      * @param buffer where to report
      */
-    void reportType(EnumMap<FileState, Set<File>> result, FileState state, StringBuilder buffer) {
+    void reportType(Map<FileState, Set<File>> result, FileState state, StringBuilder buffer) {
         String operation = state.name();
 
         Set<File> set = getFiles(result, state);
@@ -499,7 +498,7 @@ public abstract class AbstractLicenseNameMojo extends AbstractLicenseMojo {
      * @param state state of files to get
      * @return all files of the given state
      */
-    private Set<File> getFiles(EnumMap<FileState, Set<File>> result, FileState state) {
+    private Set<File> getFiles(Map<FileState, Set<File>> result, FileState state) {
         return result.get(state);
     }
 

--- a/src/main/java/org/codehaus/mojo/license/FileState.java
+++ b/src/main/java/org/codehaus/mojo/license/FileState.java
@@ -23,9 +23,9 @@ package org.codehaus.mojo.license;
  */
 
 import java.io.File;
-import java.util.EnumMap;
-import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Defines state of a file after process.
@@ -70,12 +70,7 @@ public enum FileState {
      * @param file    file to add
      * @param results dictionary to update
      */
-    public void addFile(File file, EnumMap<FileState, Set<File>> results) {
-        Set<File> fileSet = results.get(this);
-        if (fileSet == null) {
-            fileSet = new HashSet<>();
-            results.put(this, fileSet);
-        }
-        fileSet.add(file);
+    public void addFile(File file, Map<FileState, Set<File>> results) {
+        results.computeIfAbsent(this, k -> ConcurrentHashMap.newKeySet()).add(file);
     }
 }


### PR DESCRIPTION
Projects consisting of possibly thousands of files can take long time to get processed, mostly because file operations are rather slow (compared to in-memory operations), so it makes sense to speed up things if possible without breaking backwards compatibility.

A potential solution is to use several threads, so while the first thread is still blocked by an I/O operation, another thread can start processing the next file already. With multi-core CPUs being ubiquitous these days, such a rather small change can improve the build time considerably, in particular for huge projects with thousands of files and / or slows disks (like typically on NTFS). For single-core CPUs the drawback is neglectable.

*NB: This PR mimics the solution of https://github.com/mojohaus/build-helper-maven-plugin/pull/201*