### PR TITLE
Enhance exception handling for license execution when the URL tag of the license is empty.

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -47,6 +47,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -1276,11 +1277,11 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
 
         int licenseIndex = 0;
         for (ProjectLicense license : licenses) {
-            if (matchingUrlsOnly && license.getUrl() == null) {
+            if (matchingUrlsOnly && StringUtils.isNotBlank(license.getUrl())) {
                 handleError(
                         depProject,
                         "No URL for license at index " + licenseIndex + " in dependency " + depProject.toGavString());
-            } else if (license.getUrl() != null) {
+            } else if (StringUtils.isNotBlank(license.getUrl())) {
                 final String licenseUrl = urlReplacements.rewriteIfNecessary(license.getUrl());
 
                 final LicenseDownloadResult cachedResult = cache.get(licenseUrl);


### PR DESCRIPTION
1. example: pom.xml
```
<license>
  <name/>
  <url/>
  <distribution/>
</license>
```

2. error message occurs  during the execution of license:aggregate-download-licenses
  Execution default-cli of goal org.codehaus.mojo:license-maven-plugin:2.4.0:aggregate-download-licenses failed: Null URL