### PR TITLE
Add Log4j2 to SLF4J Adapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,15 @@
     </dependency>
 
     <dependency>
+      <!-- redirect log4j to slf4j -->
+      <!-- avoid errors as Log4j2 could not find a logging implementation -->
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>2.24.1</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Transitive dependencies use log4j2,
so in order to avoid errors like - Log4j2 could not find a logging implementation