### PR TITLE
Disable fail-fast build in matrix, skip download-licenses-configured IT

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,7 @@ jobs:
     with:
       ff-goal: 'verify'                # no ITs on fast fail build
       verify-goal: '-P run-its verify'
+      verify-fail-fast: false         # do not fail fast in matrix
       maven4-enabled: true
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -492,6 +492,7 @@
                   <pomExcludes>
                     <!-- failed test on GH use remote resources -->
                     <pomExclude>download-licenses-basic/pom.xml</pomExclude>
+                    <pomExclude>download-licenses-configured/pom.xml</pomExclude>
                     <pomExclude>download-licenses-force/pom.xml</pomExclude>
                   </pomExcludes>
                 </configuration>


### PR DESCRIPTION
ITs can fail due to download timeout, so don't break other builds if one has a problem 
It will be easier to re-run build