### PR TITLE
fix a ConcurrentModificationException

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java
@@ -27,11 +27,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
@@ -926,8 +928,9 @@ public abstract class AbstractAddThirdPartyMojo extends AbstractLicenseMojo {
 
             for (String excludeLicense : blackLicenses) {
                 if (licenses.contains(excludeLicense) && CollectionUtils.isNotEmpty(licenseMap.get(excludeLicense))) {
-                    // bad license found
-                    unsafeLicenses.put(excludeLicense, licenseMap.get(excludeLicense));
+                    // bad license found — store a defensive copy so subsequent mutations
+                    // on the unsafeLicenses set do not leak back into licenseMap.
+                    unsafeLicenses.put(excludeLicense, new TreeSet<>(licenseMap.get(excludeLicense)));
                 }
             }
         }
@@ -937,7 +940,9 @@ public abstract class AbstractAddThirdPartyMojo extends AbstractLicenseMojo {
             LOG.info("Included licenses (whitelist): {}", whiteLicenses);
 
             for (final String unsafelicense : unsafeLicenses.keySet()) {
-                for (MavenProject potentiallyUnsafeProject : unsafeLicenses.get(unsafelicense)) {
+                Iterator<MavenProject> it = unsafeLicenses.get(unsafelicense).iterator();
+                while (it.hasNext()) {
+                    MavenProject potentiallyUnsafeProject = it.next();
 
                     final boolean whiteListed =
                             isDependencyWhitelisted(potentiallyUnsafeProject, unsafelicense, whiteLicenses);
@@ -948,7 +953,7 @@ public abstract class AbstractAddThirdPartyMojo extends AbstractLicenseMojo {
                                 potentiallyUnsafeProject,
                                 unsafelicense);
 
-                        unsafeLicenses.get(unsafelicense).remove(potentiallyUnsafeProject);
+                        it.remove();
                     }
                 }
             }
@@ -976,11 +981,7 @@ public abstract class AbstractAddThirdPartyMojo extends AbstractLicenseMojo {
             }
         }
 
-        for (final String s : unsafeLicenses.keySet()) {
-            if (CollectionUtils.isEmpty(unsafeLicenses.get(s))) {
-                unsafeLicenses.remove(s);
-            }
-        }
+        unsafeLicenses.entrySet().removeIf(e -> CollectionUtils.isEmpty(e.getValue()));
 
         boolean safe = CollectionUtils.isEmpty(unsafeLicenses.keySet());
 
@@ -1025,7 +1026,7 @@ public abstract class AbstractAddThirdPartyMojo extends AbstractLicenseMojo {
 
             if (licenseMap.get(otherLicense).contains(dependency)) {
                 LOG.info(
-                        "License: '{}' for '{}' is OK since it is also licensed under '{}'",
+                        "'{}' is OK. It is licenced under forbidden licence '{}' but also it is licensed under '{}'",
                         dependencyLicense,
                         dependency,
                         otherLicense);

--- a/src/test/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojoTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -205,6 +206,42 @@ class AbstractAddThirdPartyMojoTest {
             mojo.licenseMap.put("UNSAFE", dualLicensedProject);
 
             assertTrue(mojo.checkForbiddenLicenses());
+        }
+
+        /**
+         * Reproduces a {@link java.util.ConcurrentModificationException} thrown from
+         * {@link AbstractAddThirdPartyMojo#checkForbiddenLicenses()} when two or more
+         * dependencies are mapped to the same blacklisted license <em>and</em> are
+         * simultaneously whitelisted via another license.
+         *
+         * <p>The inner loop iterates the {@code SortedSet} of unsafe projects and
+         * calls {@code set.remove(...)} on the very same set, which mutates the
+         * underlying {@code TreeMap}'s {@code modCount}. The next call to
+         * {@code Iterator.next()} then fails fast with a CME originating from
+         * {@code TreeMap$KeyIterator.next} (TreeSet is backed by a TreeMap).
+         *
+         * <p>Trigger conditions: at least two dependencies on the same blacklisted
+         * license, with the first iterated one being whitelisted (so the remove
+         * fires) and at least one further iteration step required afterwards.
+         */
+        @Test
+        void multipleDualLicensedProjectsDoNotThrowConcurrentModification() throws MojoExecutionException {
+            mojo.setIncludedLicenses("Good");
+            mojo.setExcludedLicenses("UNSAFE");
+
+            final MavenProject project1 = createProject("artifact1");
+            final MavenProject project2 = createProject("artifact2");
+
+            // Both projects are licensed under both UNSAFE (blacklisted)
+            // and Good (whitelisted) — i.e. dual-licensed.
+            mojo.licenseMap.put("UNSAFE", project1);
+            mojo.licenseMap.put("UNSAFE", project2);
+            mojo.licenseMap.put("Good", project1);
+            mojo.licenseMap.put("Good", project2);
+
+            // Pre-fix: throws ConcurrentModificationException (TreeMap$KeyIterator.next).
+            // Post-fix: returns true because every blacklisted project is also whitelisted.
+            assertTrue(assertDoesNotThrow(() -> mojo.checkForbiddenLicenses()));
         }
     }
 


### PR DESCRIPTION
Sorry my last Pull Request introduced a bug.

This PR fixes that causing ConcurrentModificationException on multiple dependencies have multiple licenses

Caused by: java.util.ConcurrentModificationException
    at java.util.TreeMap$PrivateEntryIterator.nextEntry (TreeMap.java:1486)
    at java.util.TreeMap$KeyIterator.next (TreeMap.java:1540)
    at org.codehaus.mojo.license.AbstractAddThirdPartyMojo.checkForbiddenLicenses (AbstractAddThirdPartyMojo.java:940)


You can reproduce the bug by just executing org.codehaus.mojo.license.AbstractAddThirdPartyMojoTest.WhitelistAndBlacklist#multipleDualLicensedProjectsDoNotThrowConcurrentModification without applying my changes in org.codehaus.mojo.license.AbstractAddThirdPartyMojo#checkForbiddenLicenses