### PR TITLE
Feat: Allow using Authentication when downloading License Texts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,7 +484,7 @@
               <dependency>
                 <groupId>com.github.tomakehurst</groupId>
                 <artifactId>wiremock-jre8-standalone</artifactId>
-                <version>3.0.1</version>
+                <version>2.35.0</version>
               </dependency>
             </dependencies>
             <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -482,9 +482,9 @@
                 <version>2.22.0</version>
               </dependency>
               <dependency>
-                <groupId>org.wiremock</groupId>
-                <artifactId>wiremock-standalone</artifactId>
-                <version>3.13.2</version>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock-jre8-standalone</artifactId>
+                <version>3.0.1</version>
               </dependency>
             </dependencies>
             <executions>

--- a/src/it/download-licenses-auth/invoker.properties
+++ b/src/it/download-licenses-auth/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = license:download-licenses
+invoker.settingsFile = src/it/settings-auth.xml

--- a/src/it/download-licenses-auth/pom.xml
+++ b/src/it/download-licenses-auth/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.license</groupId>
+  <artifactId>download-licenses-auth</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Integration Test</name>
+  <url>http://maven.apache.org</url>
+  <description>
+    Check download-licenses with Basic Authentication. Verifies that credentials are sent only to
+    URLs matching the configured serverUrl prefix, and not to other (public/third-party) URLs.
+  </description>
+
+  <!--
+    Two dependencies whose license URLs are overridden via src/license/licenses.xml:
+      - commons-logging -> http://localhost:18081/auth-licenses/apache-2.0.txt  (should receive auth)
+      - commons-codec   -> http://localhost:18081/public-licenses/mit.txt        (must NOT receive auth)
+  -->
+  <dependencies>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.6</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>download-licenses</goal>
+            </goals>
+            <configuration>
+              <!--
+                The Maven settings server ID whose credentials to use for authenticated downloads.
+                Defined in src/it/settings-auth.xml as username=testuser / password=testpass.
+              -->
+              <serverId>my-artifactory</serverId>
+              <!--
+                Only URLs starting with this prefix will receive the credentials.
+                Requests to http://localhost:18081/public-licenses/... will not include auth.
+              -->
+              <serverUrl>http://localhost:18081/auth-licenses</serverUrl>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/download-licenses-auth/pom.xml
+++ b/src/it/download-licenses-auth/pom.xml
@@ -38,6 +38,10 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <version>@project.version@</version>
+        <configuration>
+          <serverId>my-artifactory</serverId>
+          <serverUrl>http://localhost:18081/auth-licenses</serverUrl>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/src/it/download-licenses-auth/postbuild.groovy
+++ b/src/it/download-licenses-auth/postbuild.groovy
@@ -1,0 +1,42 @@
+import com.github.tomakehurst.wiremock.WireMockServer
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import static com.github.tomakehurst.wiremock.client.WireMock.matching
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly
+
+/*
+ * Verify that:
+ *   1. Both license files were successfully downloaded.
+ *   2. Credentials (Authorization: Basic ...) were sent to the URL under serverUrl prefix.
+ *   3. Credentials were NOT sent to the URL outside the serverUrl prefix.
+ */
+
+final Path basePath = basedir.toPath()
+final Path licensesDir = basePath.resolve('target/generated-resources/licenses')
+
+// 1. Verify the auth-protected license file was downloaded
+final Path authLicenseFile = licensesDir.resolve('apache license 2.0 - apache-2.0.txt')
+assert Files.exists(authLicenseFile) : "Auth-protected license file was not downloaded: ${authLicenseFile}"
+assert authLicenseFile.toFile().text.contains('Authenticated WireMock') :
+        "Auth-protected license file does not contain expected content"
+
+// 2. Verify the public license file was downloaded
+final Path publicLicenseFile = licensesDir.resolve('mit license - mit.txt')
+assert Files.exists(publicLicenseFile) : "Public license file was not downloaded: ${publicLicenseFile}"
+assert publicLicenseFile.toFile().text.contains('Public WireMock') :
+        "Public license file does not contain expected content"
+
+WireMockServer wireMockServer = context.get('wireMockServer')
+
+// 3. Verify that the Authorization header was sent to the protected URL (credentials applied)
+wireMockServer.verify(getRequestedFor(urlEqualTo('/auth-licenses/apache-2.0.txt'))
+        .withHeader('Authorization', matching('Basic .*')))
+
+// 4. Verify that the Authorization header was NOT sent to the public URL (no credential leakage)
+wireMockServer.verify(exactly(0), getRequestedFor(urlEqualTo('/public-licenses/mit.txt'))
+        .withHeader('Authorization', matching('.*')))
+
+wireMockServer.stop()

--- a/src/it/download-licenses-auth/postbuild.groovy
+++ b/src/it/download-licenses-auth/postbuild.groovy
@@ -16,27 +16,28 @@ import static com.github.tomakehurst.wiremock.client.WireMock.exactly
 
 final Path basePath = basedir.toPath()
 final Path licensesDir = basePath.resolve('target/generated-resources/licenses')
-
-// 1. Verify the auth-protected license file was downloaded
-final Path authLicenseFile = licensesDir.resolve('apache license 2.0 - apache-2.0.txt')
-assert Files.exists(authLicenseFile) : "Auth-protected license file was not downloaded: ${authLicenseFile}"
-assert authLicenseFile.toFile().text.contains('Authenticated WireMock') :
-        "Auth-protected license file does not contain expected content"
-
-// 2. Verify the public license file was downloaded
-final Path publicLicenseFile = licensesDir.resolve('mit license - mit.txt')
-assert Files.exists(publicLicenseFile) : "Public license file was not downloaded: ${publicLicenseFile}"
-assert publicLicenseFile.toFile().text.contains('Public WireMock') :
-        "Public license file does not contain expected content"
-
 WireMockServer wireMockServer = context.get('wireMockServer')
 
-// 3. Verify that the Authorization header was sent to the protected URL (credentials applied)
-wireMockServer.verify(getRequestedFor(urlEqualTo('/auth-licenses/apache-2.0.txt'))
-        .withHeader('Authorization', matching('Basic .*')))
+try {
+    // 1. Verify the auth-protected license file was downloaded
+    final Path authLicenseFile = licensesDir.resolve('apache license 2.0 - apache-2.0.txt')
+    assert Files.exists(authLicenseFile) : "Auth-protected license file was not downloaded: ${authLicenseFile}"
+    assert authLicenseFile.toFile().text.contains('Authenticated WireMock') :
+            "Auth-protected license file does not contain expected content"
 
-// 4. Verify that the Authorization header was NOT sent to the public URL (no credential leakage)
-wireMockServer.verify(exactly(0), getRequestedFor(urlEqualTo('/public-licenses/mit.txt'))
-        .withHeader('Authorization', matching('.*')))
+    // 2. Verify the public license file was downloaded
+    final Path publicLicenseFile = licensesDir.resolve('mit license - mit.txt')
+    assert Files.exists(publicLicenseFile) : "Public license file was not downloaded: ${publicLicenseFile}"
+    assert publicLicenseFile.toFile().text.contains('Public WireMock') :
+            "Public license file does not contain expected content"
 
-wireMockServer.stop()
+    // 3. Verify that the Authorization header was sent to the protected URL (credentials applied)
+    wireMockServer.verify(getRequestedFor(urlEqualTo('/auth-licenses/apache-2.0.txt'))
+            .withHeader('Authorization', matching('Basic .*')))
+
+    // 4. Verify that the Authorization header was NOT sent to the public URL (no credential leakage)
+    wireMockServer.verify(exactly(0), getRequestedFor(urlEqualTo('/public-licenses/mit.txt'))
+            .withHeader('Authorization', matching('.*')))
+} finally {
+    wireMockServer.stop()
+}

--- a/src/it/download-licenses-auth/prebuild.groovy
+++ b/src/it/download-licenses-auth/prebuild.groovy
@@ -1,0 +1,33 @@
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import static com.github.tomakehurst.wiremock.client.WireMock.get
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor
+
+/*
+ * Start a local WireMock server on port 18081 to serve license texts for both:
+ *   /auth-licenses/apache-2.0.txt  - located under the serverUrl prefix (credentials expected)
+ *   /public-licenses/mit.txt       - outside the serverUrl prefix (credentials must NOT be sent)
+ */
+WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.options()
+        .port(18081)
+        .notifier(new ConsoleNotifier(false)))
+wireMockServer.start()
+
+configureFor(wireMockServer.port())
+
+stubFor(get('/auth-licenses/apache-2.0.txt')
+        .willReturn(aResponse()
+                .withStatus(200)
+                .withBody('Apache License 2.0 text served by Authenticated WireMock')))
+
+stubFor(get('/public-licenses/mit.txt')
+        .willReturn(aResponse()
+                .withStatus(200)
+                .withBody('MIT License text served by Public WireMock')))
+
+context.put('wireMockServer', wireMockServer)
+true

--- a/src/it/download-licenses-auth/src/license/licenses.xml
+++ b/src/it/download-licenses-auth/src/license/licenses.xml
@@ -1,0 +1,24 @@
+<licenseSummary>
+  <dependencies>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://localhost:18081/auth-licenses/apache-2.0.txt</url>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>http://localhost:18081/public-licenses/mit.txt</url>
+        </license>
+      </licenses>
+    </dependency>
+  </dependencies>
+</licenseSummary>

--- a/src/it/settings-auth.xml
+++ b/src/it/settings-auth.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2008 - 2011 CodeLutin, Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<settings>
+
+  <servers>
+    <server>
+      <id>my-artifactory</id>
+      <username>testuser</username>
+      <password>testpass</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>file:///@localRepository@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>file:///@localRepository@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <pluginGroups>
+    <pluginGroup>org.codehaus.mojo</pluginGroup>
+  </pluginGroups>
+</settings>

--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -420,7 +420,7 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
     /**
      * The Maven session, used to resolve {@link #serverId} credentials from {@code settings.xml}.
      *
-     * @since 2.6.1
+     * @since 2.8.0
      */
     @Parameter(defaultValue = "${session}", readonly = true)
     private MavenSession session;
@@ -433,7 +433,7 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
      * <p>Credentials are only sent to URLs that start with {@link #serverUrl}, preventing
      * accidental credential leakage to third-party license servers.
      *
-     * @since 2.6.1
+     * @since 2.8.0
      */
     @Parameter(property = "license.serverId", defaultValue = "")
     private String serverId;
@@ -448,7 +448,7 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
      *
      * <p>Example: {@code https://artifactory.example.com/artifactory}
      *
-     * @since 2.6.1
+     * @since 2.8.0
      */
     @Parameter(property = "license.serverUrl", defaultValue = "")
     private String serverUrl;

--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -49,11 +49,16 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Proxy;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecryptionResult;
 import org.codehaus.mojo.license.api.ArtifactFilters;
 import org.codehaus.mojo.license.api.MavenProjectDependenciesConfigurator;
 import org.codehaus.mojo.license.download.Cache;
@@ -74,6 +79,7 @@ import org.codehaus.mojo.license.extended.spreadsheet.ExcelFileWriter;
 import org.codehaus.mojo.license.spdx.SpdxLicenseList;
 import org.codehaus.mojo.license.spdx.SpdxLicenseList.Attachments.ContentSanitizer;
 import org.codehaus.mojo.license.utils.FileUtil;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -410,6 +416,42 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
      */
     @Parameter(defaultValue = "${settings.proxies}", readonly = true)
     private List<Proxy> proxies;
+
+    /**
+     * The Maven session, used to resolve {@link #serverId} credentials from {@code settings.xml}.
+     *
+     * @since 2.6.1
+     */
+    @Parameter(defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    /**
+     * A server ID from {@code settings.xml} that provides authentication credentials (username,
+     * password, and optional custom HTTP headers) for downloading license files from a protected
+     * repository such as Artifactory.
+     *
+     * <p>Credentials are only sent to URLs that start with {@link #serverUrl}, preventing
+     * accidental credential leakage to third-party license servers.
+     *
+     * @since 2.6.1
+     */
+    @Parameter(property = "license.serverId", defaultValue = "")
+    private String serverId;
+
+    /**
+     * Base URL prefix that a license download URL must start with in order to receive the
+     * credentials configured by {@link #serverId}.
+     *
+     * <p>This prevents credentials from being sent to any third-party server that happens to
+     * host a license file. Only URLs starting with this value will carry the {@code Authorization}
+     * header or custom HTTP headers from the server configuration.
+     *
+     * <p>Example: {@code https://artifactory.example.com/artifactory}
+     *
+     * @since 2.6.1
+     */
+    @Parameter(property = "license.serverUrl", defaultValue = "")
+    private String serverUrl;
 
     /**
      * A flag to organize the licenses by dependencies. When this is done, each dependency will
@@ -762,6 +804,7 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
     // ----------------------------------------------------------------------
     // Plexus Components
     // ----------------------------------------------------------------------
+    private final SettingsDecrypter settingsDecrypter;
 
     // ----------------------------------------------------------------------
     // Private Fields
@@ -781,8 +824,10 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
 
     private UrlReplacements urlReplacements;
 
-    protected AbstractDownloadLicensesMojo(LicensedArtifactResolver licensedArtifactResolver) {
+    protected AbstractDownloadLicensesMojo(
+            LicensedArtifactResolver licensedArtifactResolver, SettingsDecrypter settingsDecrypter) {
         super(licensedArtifactResolver);
+        this.settingsDecrypter = settingsDecrypter;
     }
 
     protected abstract boolean isSkip();
@@ -848,13 +893,21 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
         // The resulting list of licenses after dependency resolution
         final List<ProjectLicenseInfo> depProjectLicenses = new ArrayList<>();
 
+        final Server server = decryptServer(serverId);
+        final String downloadUserName = server != null ? server.getUsername() : null;
+        final String downloadPassword = server != null ? server.getPassword() : null;
+        final Map<String, String> serverHttpHeaders = server != null ? getHttpHeaders(server) : Collections.emptyMap();
         try (LicenseDownloader licenseDownloader = new LicenseDownloader(
                 findActiveProxy(),
                 connectTimeout,
                 socketTimeout,
                 connectionRequestTimeout,
                 contentSanitizers(),
-                getCharset())) {
+                getCharset(),
+                downloadUserName,
+                downloadPassword,
+                serverUrl,
+                serverHttpHeaders)) {
             for (LicensedArtifact artifact : dependencies.values()) {
                 LOG.debug("Checking licenses for project {}", artifact);
                 final ProjectLicenseInfo depProject = createDependencyProject(artifact);
@@ -1163,6 +1216,72 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
             }
         }
         return null;
+    }
+
+    /**
+     * Looks up the server with the given {@code id} from the current Maven session's settings and
+     * decrypts any encrypted credentials.
+     *
+     * @param id the server ID from {@code settings.xml}; ignored when {@code null} or empty
+     * @return the decrypted {@link Server}, or {@code null} when not found or {@code id} is empty
+     */
+    private Server decryptServer(String id) {
+        if (StringUtils.isEmpty(id)) {
+            return null;
+        }
+        if (session == null || session.getSettings() == null) {
+            return null;
+        }
+        final Server server = session.getSettings().getServer(id);
+        if (server == null) {
+            LOG.warn("Could not find server '{}' in settings.xml - no credentials will be applied", id);
+            return null;
+        }
+        synchronized (server) {
+            final DefaultSettingsDecryptionRequest request = new DefaultSettingsDecryptionRequest(server);
+            final SettingsDecryptionResult result = settingsDecrypter.decrypt(request);
+            return result.getServer();
+        }
+    }
+
+    /**
+     * Extracts custom HTTP headers declared inside a server's {@code <configuration>} element:
+     *
+     * <pre>{@code
+     * <server>
+     *   <id>my-server</id>
+     *   <configuration>
+     *     <httpHeaders>
+     *       <property>
+     *         <name>Authorization</name>
+     *         <value>Bearer my-token</value>
+     *       </property>
+     *     </httpHeaders>
+     *   </configuration>
+     * </server>
+     * }</pre>
+     *
+     * @param server the server entry from {@code settings.xml}
+     * @return a map of header name → header value; never {@code null}
+     */
+    private Map<String, String> getHttpHeaders(Server server) {
+        if (!(server.getConfiguration() instanceof Xpp3Dom)) {
+            return Collections.emptyMap();
+        }
+        final Xpp3Dom configuration = (Xpp3Dom) server.getConfiguration();
+        final Xpp3Dom httpHeaders = configuration.getChild("httpHeaders");
+        if (httpHeaders == null) {
+            return Collections.emptyMap();
+        }
+        final Map<String, String> result = new TreeMap<>();
+        for (Xpp3Dom property : httpHeaders.getChildren("property")) {
+            final Xpp3Dom name = property.getChild("name");
+            final Xpp3Dom value = property.getChild("value");
+            if (name != null && value != null) {
+                result.put(name.getValue(), value.getValue());
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/license/AggregateDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AggregateDownloadLicensesMojo.java
@@ -33,6 +33,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.codehaus.mojo.license.api.ResolvedProjectDependencies;
 import org.codehaus.mojo.license.download.LicensedArtifact;
 import org.codehaus.mojo.license.download.LicensedArtifactResolver;
@@ -130,8 +131,9 @@ public class AggregateDownloadLicensesMojo extends AbstractDownloadLicensesMojo 
     private boolean extendedInfo;
 
     @Inject
-    public AggregateDownloadLicensesMojo(LicensedArtifactResolver licensedArtifactResolver) {
-        super(licensedArtifactResolver);
+    public AggregateDownloadLicensesMojo(
+            LicensedArtifactResolver licensedArtifactResolver, SettingsDecrypter settingsDecrypter) {
+        super(licensedArtifactResolver, settingsDecrypter);
     }
 
     // ----------------------------------------------------------------------

--- a/src/main/java/org/codehaus/mojo/license/DownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/DownloadLicensesMojo.java
@@ -31,6 +31,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.codehaus.mojo.license.api.ResolvedProjectDependencies;
 import org.codehaus.mojo.license.download.LicensedArtifact;
 import org.codehaus.mojo.license.download.LicensedArtifactResolver;
@@ -76,8 +77,9 @@ public class DownloadLicensesMojo extends AbstractDownloadLicensesMojo {
     protected boolean skipDownloadLicenses;
 
     @Inject
-    public DownloadLicensesMojo(LicensedArtifactResolver licensedArtifactResolver) {
-        super(licensedArtifactResolver);
+    public DownloadLicensesMojo(
+            LicensedArtifactResolver licensedArtifactResolver, SettingsDecrypter settingsDecrypter) {
+        super(licensedArtifactResolver, settingsDecrypter);
     }
 
     // ----------------------------------------------------------------------

--- a/src/main/java/org/codehaus/mojo/license/download/LicenseDownloader.java
+++ b/src/main/java/org/codehaus/mojo/license/download/LicenseDownloader.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -38,12 +39,14 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
@@ -53,14 +56,18 @@ import org.apache.http.StatusLine;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.config.RequestConfig.Builder;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.conn.routing.HttpRoutePlanner;
 import org.apache.http.entity.ContentType;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -90,6 +97,24 @@ public class LicenseDownloader implements AutoCloseable {
     private final Map<String, ContentSanitizer> contentSanitizers;
     private final Charset charset;
 
+    /** Credentials for authenticated downloads. May be {@code null} if no authentication is configured. */
+    private final String userName;
+
+    private final String password;
+
+    /**
+     * Base URL prefix used to determine which download URLs should receive authentication credentials.
+     * Credentials are sent only when a license URL starts with this prefix.
+     * May be {@code null} if no authentication is configured.
+     */
+    private final String serverUrl;
+
+    /** Additional HTTP headers to include in authenticated requests (e.g. custom tokens). May be empty. */
+    private final Map<String, String> httpHeaders;
+
+    /**
+     * Creates a new {@code LicenseDownloader} without authentication. Proxy settings and timeouts are still applied.
+     */
     public LicenseDownloader(
             Proxy proxy,
             int connectTimeout,
@@ -97,8 +122,55 @@ public class LicenseDownloader implements AutoCloseable {
             int connectionRequestTimeout,
             Map<String, ContentSanitizer> contentSanitizers,
             Charset charset) {
+        this(
+                proxy,
+                connectTimeout,
+                socketTimeout,
+                connectionRequestTimeout,
+                contentSanitizers,
+                charset,
+                null,
+                null,
+                null,
+                Collections.emptyMap());
+    }
+
+    /**
+     * Creates a new {@code LicenseDownloader} with optional authentication.
+     *
+     * <p>Credentials ({@code userName}/{@code password}) and {@code httpHeaders} are sent only to URLs that start
+     * with {@code serverUrl}, preventing credential leakage to third-party license servers.
+     *
+     * @param proxy               optional proxy configuration from {@code settings.xml}
+     * @param connectTimeout      HTTP connection timeout in milliseconds
+     * @param socketTimeout       HTTP socket (read) timeout in milliseconds
+     * @param connectionRequestTimeout HTTP connection-pool request timeout in milliseconds
+     * @param contentSanitizers   optional content sanitizers keyed by an id string
+     * @param charset             charset used when reading text license content
+     * @param userName            username for preemptive Basic Authentication, or {@code null}/empty to disable
+     * @param password            password for preemptive Basic Authentication, or {@code null}/empty to disable
+     * @param serverUrl           URL prefix that a license URL must start with in order to receive credentials;
+     *                            {@code null} disables authentication for all URLs
+     * @param httpHeaders         additional HTTP headers sent only to matching URLs (e.g. {@code Authorization: Bearer})
+     */
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public LicenseDownloader(
+            Proxy proxy,
+            int connectTimeout,
+            int socketTimeout,
+            int connectionRequestTimeout,
+            Map<String, ContentSanitizer> contentSanitizers,
+            Charset charset,
+            String userName,
+            String password,
+            String serverUrl,
+            Map<String, String> httpHeaders) {
         this.contentSanitizers = contentSanitizers;
         this.charset = charset;
+        this.userName = userName;
+        this.password = password;
+        this.serverUrl = serverUrl;
+        this.httpHeaders = httpHeaders != null ? httpHeaders : Collections.emptyMap();
         final Builder configBuilder = RequestConfig.copy(RequestConfig.DEFAULT) //
                 .setConnectTimeout(connectTimeout) //
                 .setSocketTimeout(socketTimeout) //
@@ -184,7 +256,23 @@ public class LicenseDownloader implements AutoCloseable {
             }
         } else {
             LOG.debug("About to download '{}'", licenseUrlString);
-            try (CloseableHttpResponse response = client.execute(new HttpGet(licenseUrlString))) {
+            final HttpGet request = new HttpGet(licenseUrlString);
+            final HttpClientContext context;
+            if (shouldAuthenticate(licenseUrlString)) {
+                LOG.debug("Applying authentication for URL '{}' (matches serverUrl '{}')", licenseUrlString, serverUrl);
+                context = makeLocalContext(new URL(licenseUrlString));
+                for (Map.Entry<String, String> header : httpHeaders.entrySet()) {
+                    LOG.debug(
+                            "Adding HTTP header '{}' to authenticated request for '{}'",
+                            header.getKey(),
+                            licenseUrlString);
+                    request.addHeader(header.getKey(), header.getValue());
+                }
+            } else {
+                context = null;
+            }
+            try (CloseableHttpResponse response =
+                    context != null ? client.execute(request, context) : client.execute(request)) {
                 final StatusLine statusLine = response.getStatusLine();
                 if (statusLine.getStatusCode() != HttpStatus.SC_OK) {
                     return LicenseDownloadResult.failure("'" + licenseUrlString + "' returned "
@@ -291,6 +379,52 @@ public class LicenseDownloader implements AutoCloseable {
             return new File(outputFile.getParentFile(), newFileName);
         }
         return outputFile;
+    }
+
+    /**
+     * Returns {@code true} when credentials should be applied to the given download URL.
+     *
+     * <p>Credentials are only applied when <em>all</em> of the following conditions hold:
+     * <ul>
+     *   <li>{@link #serverUrl} is configured and non-empty</li>
+     *   <li>{@link #userName} is configured and non-empty</li>
+     *   <li>the download {@code url} starts with {@link #serverUrl}</li>
+     * </ul>
+     *
+     * <p>This prevents credential leakage to third-party license servers that are not the
+     * configured authenticated server.
+     *
+     * @param url the license download URL to check
+     * @return {@code true} if the URL matches the configured server and credentials should be sent
+     */
+    boolean shouldAuthenticate(String url) {
+        return StringUtils.isNotEmpty(serverUrl) && StringUtils.isNotEmpty(userName) && url.startsWith(serverUrl);
+    }
+
+    /**
+     * Creates an {@link HttpClientContext} with preemptive Basic Authentication for the given URL.
+     *
+     * <p>The context contains both a {@link BasicAuthCache} (for preemptive auth) and a
+     * {@link BasicCredentialsProvider} scoped to the target host, so credentials are sent on
+     * the first request without waiting for a server challenge.
+     *
+     * @param requestUrl the URL to authenticate against
+     * @return a configured {@link HttpClientContext} for an authenticated request
+     */
+    private HttpClientContext makeLocalContext(URL requestUrl) {
+        final HttpHost target = new HttpHost(requestUrl.getHost(), requestUrl.getPort(), requestUrl.getProtocol());
+        // Preemptive Basic Auth: register the target host in the auth cache
+        final AuthCache authCache = new BasicAuthCache();
+        authCache.put(target, new BasicScheme());
+        // Provide credentials scoped to the target host
+        final CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        credsProvider.setCredentials(
+                new AuthScope(requestUrl.getHost(), requestUrl.getPort()),
+                new UsernamePasswordCredentials(userName, password));
+        final HttpClientContext localContext = HttpClientContext.create();
+        localContext.setAuthCache(authCache);
+        localContext.setCredentialsProvider(credsProvider);
+        return localContext;
     }
 
     @Override

--- a/src/test/java/org/codehaus/mojo/license/download/LicenseDownloaderTest.java
+++ b/src/test/java/org/codehaus/mojo/license/download/LicenseDownloaderTest.java
@@ -23,10 +23,14 @@ package org.codehaus.mojo.license.download;
  */
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LicenseDownloaderTest {
 
@@ -40,5 +44,80 @@ class LicenseDownloaderTest {
         final File in = new File(input);
         final File result = LicenseDownloader.updateFileExtension(in, mimeType);
         assertEquals(expected, result.getPath().replace('\\', '/'));
+    }
+
+    // -----------------------------------------------------------------------
+    // shouldAuthenticate tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    void shouldAuthenticateMatchingUrl() {
+        LicenseDownloader downloader =
+                downloaderWithAuth("testuser", "testpass", "https://artifactory.example.com/artifactory");
+        assertTrue(downloader.shouldAuthenticate(
+                "https://artifactory.example.com/artifactory/libs-release/licenses/apache-2.0.txt"));
+    }
+
+    @Test
+    void shouldNotAuthenticateNonMatchingHost() {
+        LicenseDownloader downloader =
+                downloaderWithAuth("testuser", "testpass", "https://artifactory.example.com/artifactory");
+        assertFalse(downloader.shouldAuthenticate("https://www.apache.org/licenses/LICENSE-2.0.txt"));
+    }
+
+    @Test
+    void shouldAuthenticateUrlExactlyMatchingServerUrl() {
+        LicenseDownloader downloader =
+                downloaderWithAuth("testuser", "testpass", "https://artifactory.example.com/artifactory");
+        assertTrue(downloader.shouldAuthenticate("https://artifactory.example.com/artifactory"));
+    }
+
+    @Test
+    void shouldNotAuthenticateWhenServerUrlIsNull() {
+        LicenseDownloader downloader = downloaderWithAuth("testuser", "testpass", null);
+        assertFalse(downloader.shouldAuthenticate("https://artifactory.example.com/artifactory/license.txt"));
+    }
+
+    @Test
+    void shouldNotAuthenticateWhenServerUrlIsEmpty() {
+        LicenseDownloader downloader = downloaderWithAuth("testuser", "testpass", "");
+        assertFalse(downloader.shouldAuthenticate("https://artifactory.example.com/artifactory/license.txt"));
+    }
+
+    @Test
+    void shouldNotAuthenticateWhenUserNameIsEmpty() {
+        LicenseDownloader downloader =
+                downloaderWithAuth("", "testpass", "https://artifactory.example.com/artifactory");
+        assertFalse(downloader.shouldAuthenticate("https://artifactory.example.com/artifactory/license.txt"));
+    }
+
+    @Test
+    void shouldNotAuthenticateWhenUserNameIsNull() {
+        LicenseDownloader downloader =
+                downloaderWithAuth(null, "testpass", "https://artifactory.example.com/artifactory");
+        assertFalse(downloader.shouldAuthenticate("https://artifactory.example.com/artifactory/license.txt"));
+    }
+
+    @Test
+    void shouldNotAuthenticateWhenServerUrlIsSubstringButNotPrefix() {
+        LicenseDownloader downloader =
+                downloaderWithAuth("testuser", "testpass", "https://artifactory.example.com/artifactory");
+        // Different path that merely contains the serverUrl as a substring but doesn't start with it
+        assertFalse(downloader.shouldAuthenticate(
+                "https://other.example.com/?ref=https://artifactory.example.com/artifactory"));
+    }
+
+    private static LicenseDownloader downloaderWithAuth(String userName, String password, String serverUrl) {
+        return new LicenseDownloader(
+                null,
+                5000,
+                5000,
+                5000,
+                Collections.emptyMap(),
+                StandardCharsets.UTF_8,
+                userName,
+                password,
+                serverUrl,
+                Collections.emptyMap());
     }
 }


### PR DESCRIPTION
We're using an internal mirror for all artifacts that are used for building our software, including the license texts. This way, we do not depend directly on any external systems and ensure we're always able to build and release new versions of our software. However, it is only possible to access our mirrors using authentication, which was not yet supported by the license-maven-plugin. In this PR, authentication is added to the license-maven-plugin. The implementation re-uses the authentication from maven while also allowing to define a Base URL to ensure that credentials are not leaked to any Third Party systems.