### PR TITLE
Stop dependabot from updating integration test fixtures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,11 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    # Integration test fixtures pin their dependency versions on purpose:
+    # the postbuild assertions and expected XML files contain those versions
+    # verbatim, so a bump there is always red until the assertions are updated.
+    exclude-paths:
+      - "src/it/**"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
The `src/it` projects assert their dependency versions verbatim, so every dependabot bump under that tree fails the IT it touches. #639, #662, #664, #703, #705 and #711 are all red for this reason and none of them can be merged as-is.

`exclude-paths` is matched by dependabot-core against the glob, so `src/it/**` keeps the root `pom.xml` in scope while leaving fixtures alone. Bumping a fixture stays a deliberate change: update the version and the assertion in the same commit.

Does not address #692 (`xml-apis` 1.4.01 -> 2.0.2), which lives in the root pom - that one is a version-ordering artifact, 2.0.2 was published in 2005 and 1.4.01 in 2011, and it breaks `LicenseSummaryTest` with `NoClassDefFoundError: org/w3c/dom/ElementTraversal`. It needs an `ignore` entry or a close.