### PR TITLE
Stop dependabot from offering wiremock 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       - "src/it/**"
     schedule:
       interval: "daily"
+    ignore:
+      # wiremock 3 requires Java 11; the integration tests still run on Java 8.
+      - dependency-name: "com.github.tomakehurst:wiremock-jre8-standalone"
+        versions: ["[3.0.0,)"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
wiremock 3 is Java 11 bytecode; the `jdk-8` matrix job runs the integration tests under Java 8 and #722 dies there with `UnsupportedClassVersionError: com/github/tomakehurst/wiremock/WireMockServer ... class file version 55.0`. The bump also crosses a coordinate change (`com.github.tomakehurst:wiremock-jre8-standalone` became `org.wiremock:wiremock-standalone` in 3.x), so it is a migration rather than an update. Drop the ignore when `requiredJavaVersion` moves off 8.

Supersedes #722.

*This change was created with AI assistance.*