### PR TITLE
Send a plugin-specific User-Agent when downloading licenses

### DIFF
--- a/src/it/download-licenses-auth/postbuild.groovy
+++ b/src/it/download-licenses-auth/postbuild.groovy
@@ -38,6 +38,10 @@ try {
     // 4. Verify that the Authorization header was NOT sent to the public URL (no credential leakage)
     wireMockServer.verify(exactly(0), getRequestedFor(urlEqualTo('/public-licenses/mit.txt'))
             .withHeader('Authorization', matching('.*')))
+
+    // 5. Verify the plugin identifies itself instead of using the Apache HttpClient default user agent
+    wireMockServer.verify(getRequestedFor(urlEqualTo('/public-licenses/mit.txt'))
+            .withHeader('User-Agent', matching('license-maven-plugin/\\d.+')))
 } finally {
     wireMockServer.stop()
 }

--- a/src/main/java/org/codehaus/mojo/license/download/LicenseDownloader.java
+++ b/src/main/java/org/codehaus/mojo/license/download/LicenseDownloader.java
@@ -92,6 +92,12 @@ public class LicenseDownloader implements AutoCloseable {
 
     private static final Pattern EXTENSION_PATTERN = Pattern.compile("\\.[a-z]{1,4}$", Pattern.CASE_INSENSITIVE);
 
+    /**
+     * Sent with every license download. Some license hosts, gnu.org among them, answer the Apache HttpClient default
+     * user agent with {@code 429 Too Many Requests} on the very first request.
+     */
+    private static final String USER_AGENT = userAgent();
+
     private final CloseableHttpClient client;
 
     private final Map<String, ContentSanitizer> contentSanitizers;
@@ -181,7 +187,9 @@ public class LicenseDownloader implements AutoCloseable {
             configBuilder.setProxy(new HttpHost(proxy.getHost(), proxy.getPort(), proxy.getProtocol()));
         }
 
-        HttpClientBuilder clientBuilder = HttpClients.custom().setDefaultRequestConfig(configBuilder.build());
+        HttpClientBuilder clientBuilder = HttpClients.custom()
+                .setDefaultRequestConfig(configBuilder.build())
+                .setUserAgent(USER_AGENT);
         if (proxy != null) {
             if (proxy.getUsername() != null && proxy.getPassword() != null) {
                 final CredentialsProvider credsProvider = new BasicCredentialsProvider();
@@ -332,6 +340,11 @@ public class LicenseDownloader implements AutoCloseable {
                 }
             }
         }
+    }
+
+    private static String userAgent() {
+        final String version = LicenseDownloader.class.getPackage().getImplementationVersion();
+        return "license-maven-plugin/" + (version != null ? version : "unknown");
     }
 
     static LicenseDownloadResult sanitize(


### PR DESCRIPTION
gnu.org answers the Apache HttpClient default user agent with `429 Too Many Requests` on the very first request, so `download-licenses` never retrieves a license from one of the most frequently referenced hosts. The plugin now identifies itself as `license-maven-plugin/<version>`, taken from the jar manifest `Implementation-Version`.

Extracted from #622, where @Master-Code-Programmer diagnosed the cause. That PR sends `Wget/1.21.4`; it also adds an `https://` and then plaintext `http://` retry for protocol-less license URLs, which is a separate behaviour change and stays out of this PR.

Verified: `mvn verify -Prun-its -Dinvoker.test=download-licenses-auth` passes, and reverting only the `LicenseDownloader` change fails the new assertion with `User-Agent: Apache-HttpClient/4.5.14 (Java/25.0.4)`.

*This change was created with AI assistance.*