### PR TITLE
Stop warning about dependencies that are not archives

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/download/LicensedArtifact.java
+++ b/src/main/java/org/codehaus/mojo/license/download/LicensedArtifact.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -241,6 +242,12 @@ public class LicensedArtifact {
                         }
                     }
                 }
+            } catch (ZipException e) {
+                // Dependencies are not always archives: .pom, .exe, .so and .dylib artifacts all end up here.
+                LOG.debug(
+                        "Artifact file \"{}\" is not a ZIP archive, no extended information read from it",
+                        artifact.getFile(),
+                        e);
             } catch (IOException e) {
                 LOG.warn("Can't open zip file \"" + artifact.getFile() + "\"", e);
             }

--- a/src/test/java/org/codehaus/mojo/license/download/LicensedArtifactTest.java
+++ b/src/test/java/org/codehaus/mojo/license/download/LicensedArtifactTest.java
@@ -1,0 +1,98 @@
+package org.codehaus.mojo.license.download;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2026 Codehaus
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.codehaus.mojo.license.extended.ExtendedInfo;
+import org.codehaus.mojo.license.extended.InfoFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LicensedArtifactTest {
+
+    @TempDir
+    File tempDir;
+
+    /** Dependencies are not always archives; a {@code pom} or native dependency must not lose its extended info. */
+    @Test
+    void extendedInfoOfNonArchiveArtifact() throws IOException {
+        final File file = new File(tempDir, "test-1.0.pom");
+        Files.write(file.toPath(), "<project/>".getBytes(StandardCharsets.UTF_8));
+
+        final ExtendedInfo extendedInfo = extendedInfoOf(file, "pom");
+
+        assertNotNull(extendedInfo);
+        assertTrue(extendedInfo.getInfoFiles().isEmpty());
+    }
+
+    @Test
+    void extendedInfoOfJarArtifact() throws IOException {
+        final File file = new File(tempDir, "test-1.0.jar");
+        final Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        manifest.getMainAttributes().put(Attributes.Name.IMPLEMENTATION_VENDOR, "The Test Project");
+        try (OutputStream out = new FileOutputStream(file);
+                JarOutputStream jar = new JarOutputStream(out, manifest)) {
+            jar.putNextEntry(new JarEntry("META-INF/LICENSE.txt"));
+            jar.write("Apache License, Version 2.0".getBytes(StandardCharsets.UTF_8));
+            jar.closeEntry();
+        }
+
+        final ExtendedInfo extendedInfo = extendedInfoOf(file, "jar");
+
+        assertNotNull(extendedInfo);
+        assertEquals("The Test Project", extendedInfo.getImplementationVendor());
+        assertEquals(1, extendedInfo.getInfoFiles().size());
+        final InfoFile infoFile = extendedInfo.getInfoFiles().get(0);
+        assertEquals("META-INF/LICENSE.txt", infoFile.getFileName());
+        assertEquals(InfoFile.Type.LICENSE, infoFile.getType());
+    }
+
+    private static ExtendedInfo extendedInfoOf(File file, String type) {
+        final Artifact artifact =
+                new DefaultArtifact("org.test", "test", "1.0", "compile", type, null, new DefaultArtifactHandler(type));
+        artifact.setFile(file);
+        final ExtendedInfo extendedInfo =
+                new LicensedArtifact.Builder(artifact, true).build().getExtendedInfos();
+        assertSame(artifact, extendedInfo.getArtifact());
+        return extendedInfo;
+    }
+}


### PR DESCRIPTION
A dependency whose file is not a ZIP archive — `pom` type, or a native `.exe`, `.so`, `.dylib` — reaches `ZipFile` like any other, and the resulting `ZipException` was logged at WARN with a full stack trace once per dependency. Nothing is wrong there, so it is now a debug message; the artifact keeps its `ExtendedInfo` either way.

Behaviour is otherwise unchanged: the exception was already caught, so this is log noise rather than a failure. `LicensedArtifactTest` is new and pins both paths, including the JAR one that has to keep reading the manifest and `META-INF/LICENSE.txt`.

Extracted from #622, where @Master-Code-Programmer reported the case. That PR skipped non-archives by an extension whitelist of `jar` and `zip`, which would also skip `war`, `aar` and the other archive packagings, and returned `null` instead of the artifact info.

*This change was created with AI assistance.*