### PR TITLE
Classify licenses as forbidden, problematic or ok

### DIFF
--- a/src/it/download-licenses-configured/licenses-license-match.expected.xml
+++ b/src/it/download-licenses-configured/licenses-license-match.expected.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<licenseSummary>
+  <dependencies>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.0</version>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <file>apache-license-2.0-license-2.0.txt</file>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>3.1</version>
+      <licenses>
+        <license>
+          <name>BSD 3-Clause ASM</name>
+          <url>https://gitlab.ow2.org/asm/asm/raw/ASM_3_1_MVN/LICENSE.txt</url>
+          <file>bsd-3-clause-asm-license.txt</file>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>aopalliance</groupId>
+      <artifactId>aopalliance</artifactId>
+      <version>1.0</version>
+      <licenses>
+        <license>
+          <name>Public Domain</name>
+        </license>
+      </licenses>
+    </dependency>
+  </dependencies>
+</licenseSummary>

--- a/src/it/download-licenses-configured/pom.xml
+++ b/src/it/download-licenses-configured/pom.xml
@@ -111,6 +111,36 @@
             </configuration>
           </execution>
           <execution>
+            <id>license-match</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>download-licenses</goal>
+            </goals>
+            <configuration>
+              <licensesConfigFile>${basedir}/src/license/licenses-config-no-download.xml</licensesConfigFile>
+              <licensesOutputDirectory>${project.build.directory}/license-match/licenses</licensesOutputDirectory>
+              <licensesOutputFile>${project.build.directory}/license-match/licenses.xml</licensesOutputFile>
+              <!-- The lists are deliberately upside down: this order is the reverse of the order the
+                   dependencies resolve in, so the expected file also fails if orderBy is ignored. -->
+              <orderBy>licenseMatch</orderBy>
+              <forbiddenLicenses>
+                <forbiddenLicense>apache license 2.0</forbiddenLicense>
+              </forbiddenLicenses>
+              <problematicLicenses>
+                <problematicLicense>BSD 3-Clause ASM</problematicLicense>
+              </problematicLicenses>
+              <okLicenses>
+                <okLicense>Public Domain</okLicense>
+              </okLicenses>
+              <licenseUrlFileNameSanitizers>
+                <licenseUrlFileNameSanitizer>
+                  <regexp>[\s-_]+</regexp>
+                  <replacement>-</replacement>
+                </licenseUrlFileNameSanitizer>
+              </licenseUrlFileNameSanitizers>
+            </configuration>
+          </execution>
+          <execution>
             <id>delete-orphans</id>
             <phase>validate</phase>
             <goals>

--- a/src/it/download-licenses-configured/postbuild.groovy
+++ b/src/it/download-licenses-configured/postbuild.groovy
@@ -112,6 +112,14 @@ return {
     assert expectedLicensesXml.toFile().text.equals(licensesXml.toFile().text)
     return true
 }() && {
+    final String id = 'license-match'
+    final Path outputBase = basePath.resolve('target/' + id)
+
+    final Path expectedLicensesXml = basePath.resolve('licenses-'+ id +'.expected.xml')
+    final Path licensesXml = outputBase.resolve('licenses.xml')
+    assert expectedLicensesXml.toFile().text.equals(licensesXml.toFile().text)
+    return true
+}() && {
     final String id = 'content-sanitizers'
     final Path outputBase = basePath.resolve('target/' + id)
 

--- a/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
+++ b/src/main/java/org/codehaus/mojo/license/AbstractDownloadLicensesMojo.java
@@ -63,6 +63,7 @@ import org.codehaus.mojo.license.api.ArtifactFilters;
 import org.codehaus.mojo.license.api.MavenProjectDependenciesConfigurator;
 import org.codehaus.mojo.license.download.Cache;
 import org.codehaus.mojo.license.download.FileNameEntry;
+import org.codehaus.mojo.license.download.LicenseClassifier;
 import org.codehaus.mojo.license.download.LicenseDownloader;
 import org.codehaus.mojo.license.download.LicenseDownloader.LicenseDownloadResult;
 import org.codehaus.mojo.license.download.LicenseMatchers;
@@ -481,6 +482,36 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
      */
     @Parameter(property = "license.orderBy", defaultValue = "none")
     private OrderBy orderBy;
+
+    /**
+     * The names of the licenses that must not appear in the report at all.
+     *
+     * <p>Names are matched ignoring case and surrounding whitespace. Use {@link #licenseMerges} to bring the
+     * spelling variants of one license together first.
+     *
+     * @see OrderBy#licenseMatch
+     * @since 2.8.0
+     */
+    @Parameter(property = "license.forbiddenLicenses")
+    private List<String> forbiddenLicenses;
+
+    /**
+     * The names of the licenses that need a second look.
+     *
+     * @see #forbiddenLicenses
+     * @since 2.8.0
+     */
+    @Parameter(property = "license.problematicLicenses")
+    private List<String> problematicLicenses;
+
+    /**
+     * The names of the licenses that have been signed off.
+     *
+     * @see #forbiddenLicenses
+     * @since 2.8.0
+     */
+    @Parameter(property = "license.okLicenses")
+    private List<String> okLicenses;
 
     /**
      * A filter to exclude some GroupIds
@@ -1143,13 +1174,23 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
     }
 
     /**
+     * The classification of the license names configured on this mojo.
+     *
+     * @return the classifier, never {@code null}
+     */
+    protected LicenseClassifier licenseClassifier() {
+        return new LicenseClassifier(forbiddenLicenses, problematicLicenses, okLicenses);
+    }
+
+    /**
      * Orders the dependencies as requested by {@link #orderBy}.
      *
      * @param depProjectLicenses the dependencies, ordered in place
      * @return whether the dependencies were ordered
      */
     private boolean sortDependencies(List<ProjectLicenseInfo> depProjectLicenses) {
-        final Comparator<ProjectLicenseInfo> comparator = ProjectLicenseInfoComparators.of(orderBy);
+        final Comparator<ProjectLicenseInfo> comparator =
+                ProjectLicenseInfoComparators.of(orderBy, licenseClassifier());
         if (comparator == null) {
             return false;
         }
@@ -1593,7 +1634,14 @@ public abstract class AbstractDownloadLicensesMojo extends AbstractLicensesXmlMo
          * The license of the dependency. Dependencies with more than one license are ordered by the alphabetically
          * first of them, dependencies without a license come last.
          */
-        licenseName
+        licenseName,
+        /**
+         * How the license of the dependency compares against {@link #forbiddenLicenses},
+         * {@link #problematicLicenses} and {@link #okLicenses}, in that order, with the dependencies whose licenses
+         * are in none of the lists last. Dependencies with more than one license are ordered by the most worrying
+         * of them.
+         */
+        licenseMatch
     }
 
     public enum ErrorRemedy {

--- a/src/main/java/org/codehaus/mojo/license/ProjectLicenseInfoComparators.java
+++ b/src/main/java/org/codehaus/mojo/license/ProjectLicenseInfoComparators.java
@@ -25,6 +25,7 @@ package org.codehaus.mojo.license;
 import java.util.Comparator;
 
 import org.codehaus.mojo.license.AbstractDownloadLicensesMojo.OrderBy;
+import org.codehaus.mojo.license.download.LicenseClassifier;
 import org.codehaus.mojo.license.download.ProjectLicense;
 import org.codehaus.mojo.license.download.ProjectLicenseInfo;
 import org.codehaus.mojo.license.extended.ExtendedInfo;
@@ -51,9 +52,10 @@ final class ProjectLicenseInfoComparators {
      * Returns the comparator for the given order.
      *
      * @param orderBy the requested order, may be {@code null}
+     * @param classifier the license classification behind {@link OrderBy#licenseMatch}
      * @return the comparator, or {@code null} if the dependencies should be left in the order they were resolved in
      */
-    static Comparator<ProjectLicenseInfo> of(OrderBy orderBy) {
+    static Comparator<ProjectLicenseInfo> of(OrderBy orderBy, LicenseClassifier classifier) {
         if (orderBy == null) {
             return null;
         }
@@ -67,6 +69,10 @@ final class ProjectLicenseInfoComparators {
                 return GAV;
             case licenseName:
                 return Comparator.comparing(ProjectLicenseInfoComparators::firstLicenseName, TEXT)
+                        .thenComparing(GAV);
+            case licenseMatch:
+                return Comparator.comparing((ProjectLicenseInfo info) -> classifier.classify(info))
+                        .thenComparing(ProjectLicenseInfoComparators::firstLicenseName, TEXT)
                         .thenComparing(GAV);
             default:
                 throw new IllegalArgumentException("Unexpected " + OrderBy.class.getName() + ": " + orderBy);

--- a/src/main/java/org/codehaus/mojo/license/download/LicenseClassifier.java
+++ b/src/main/java/org/codehaus/mojo/license/download/LicenseClassifier.java
@@ -1,0 +1,133 @@
+package org.codehaus.mojo.license.download;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2026 Codehaus
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Sorts license names into the categories a reader of a license report cares about: the ones that were signed off,
+ * the ones that need a second look, the ones that must not appear at all, and everything nobody has classified yet.
+ *
+ * <p>Names are matched ignoring case and surrounding whitespace. Use {@code licenseMerges} to bring the spelling
+ * variants of one license together before they reach this point.
+ *
+ * @since 2.8.0
+ */
+public class LicenseClassifier {
+
+    /**
+     * How a license compares against the configured lists, from the most to the least worrying. The order of the
+     * constants is the order dependencies appear in when ordered by license match.
+     */
+    public enum LicenseMatch {
+        /** The license is listed in {@code forbiddenLicenses}. */
+        forbidden,
+        /** The license is listed in {@code problematicLicenses}. */
+        problematic,
+        /** The license is listed in {@code okLicenses}. */
+        ok,
+        /** The license is in none of the lists, or the dependency declares no license at all. */
+        unknown
+    }
+
+    private final Set<String> forbidden;
+    private final Set<String> problematic;
+    private final Set<String> ok;
+
+    public LicenseClassifier(
+            Collection<String> forbiddenLicenses,
+            Collection<String> problematicLicenses,
+            Collection<String> okLicenses) {
+        this.forbidden = names(forbiddenLicenses);
+        this.problematic = names(problematicLicenses);
+        this.ok = names(okLicenses);
+    }
+
+    /**
+     * Whether any license was classified at all. A classifier without a single configured name leaves every license
+     * {@link LicenseMatch#unknown}, so callers can skip the work entirely.
+     *
+     * @return whether at least one license name is configured
+     */
+    public boolean isEmpty() {
+        return forbidden.isEmpty() && problematic.isEmpty() && ok.isEmpty();
+    }
+
+    /**
+     * Classifies a single license.
+     *
+     * @param license the license, may be {@code null}
+     * @return the category the license falls into, never {@code null}
+     */
+    public LicenseMatch classify(ProjectLicense license) {
+        final String name = license != null ? license.getName() : null;
+        if (name == null) {
+            return LicenseMatch.unknown;
+        }
+        final String key = name.trim();
+        if (forbidden.contains(key)) {
+            return LicenseMatch.forbidden;
+        }
+        if (problematic.contains(key)) {
+            return LicenseMatch.problematic;
+        }
+        if (ok.contains(key)) {
+            return LicenseMatch.ok;
+        }
+        return LicenseMatch.unknown;
+    }
+
+    /**
+     * Classifies a dependency by the most worrying of its licenses, so that a dependency offering both a forbidden
+     * and an approved license is not filed away as approved.
+     *
+     * @param info the dependency
+     * @return the category the dependency falls into, never {@code null}
+     */
+    public LicenseMatch classify(ProjectLicenseInfo info) {
+        LicenseMatch worst = LicenseMatch.unknown;
+        for (ProjectLicense license : info.getLicenses()) {
+            final LicenseMatch match = classify(license);
+            if (match.ordinal() < worst.ordinal()) {
+                worst = match;
+            }
+        }
+        return worst;
+    }
+
+    private static Set<String> names(Collection<String> licenseNames) {
+        if (licenseNames == null || licenseNames.isEmpty()) {
+            return Collections.emptySet();
+        }
+        final Set<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        for (String licenseName : licenseNames) {
+            if (licenseName != null && !licenseName.trim().isEmpty()) {
+                result.add(licenseName.trim());
+            }
+        }
+        return result;
+    }
+}

--- a/src/site/apt/examples/example-download-licenses.apt.vm
+++ b/src/site/apt/examples/example-download-licenses.apt.vm
@@ -103,12 +103,45 @@ mvn package
 | <<<licenseName>>>    | The license. Dependencies with more than one license are ordered by the   |
 |                      | alphabetically first of them, dependencies without a license come last.   |
 *----------------------+--------------------------------------------------------------------------+
+| <<<licenseMatch>>>   | How the license compares against the lists described in                   |
+|                      | {{{Classifying_the_Licenses}Classifying the Licenses}}, worst first.      |
+*----------------------+--------------------------------------------------------------------------+
 
   Dependencies that compare equal are ordered by group id, artifact id and version, so the report is
   the same on every run.
 
   <<<orderBy>>> replaces <<<sortByGroupIdAndArtifactId>>>, which is deprecated. The old parameter
   still works, and still applies when <<<orderBy>>> is left at <<<none>>>.
+
+* Classifying the Licenses
+
+  Three lists say which licenses have been signed off, which need a second look, and which must not
+  appear at all:
+
+-------------------
+<configuration>
+  <forbiddenLicenses>
+    <forbiddenLicense>GNU General Public License v3.0</forbiddenLicense>
+  </forbiddenLicenses>
+  <problematicLicenses>
+    <problematicLicense>Eclipse Public License 2.0</problematicLicense>
+  </problematicLicenses>
+  <okLicenses>
+    <okLicense>Apache License 2.0</okLicense>
+    <okLicense>MIT License</okLicense>
+  </okLicenses>
+  <orderBy>licenseMatch</orderBy>
+</configuration>
+-------------------
+
+  With <<<orderBy>>> set to <<<licenseMatch>>>, the dependencies come out worst first: the forbidden
+  licenses, then the problematic ones, then the approved ones, and last the ones in none of the
+  lists. A dependency offering several licenses is classified by the most worrying of them, so a
+  dependency under either Apache or GPL is not filed away as approved.
+
+  Names are matched ignoring case and surrounding whitespace. POMs spell the same license in many
+  ways, so use <<<licenseMerges>>> to bring the spellings of one license together; a name that no
+  list matches is not reported, it simply counts as unclassified.
 
 * Manual License Configuration
 

--- a/src/test/java/org/codehaus/mojo/license/ProjectLicenseInfoComparatorsTest.java
+++ b/src/test/java/org/codehaus/mojo/license/ProjectLicenseInfoComparatorsTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.codehaus.mojo.license.AbstractDownloadLicensesMojo.OrderBy;
+import org.codehaus.mojo.license.download.LicenseClassifier;
 import org.codehaus.mojo.license.download.ProjectLicense;
 import org.codehaus.mojo.license.download.ProjectLicenseInfo;
 import org.codehaus.mojo.license.extended.ExtendedInfo;
@@ -39,10 +40,38 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ProjectLicenseInfoComparatorsTest {
 
+    private static final LicenseClassifier NO_LICENSES_CLASSIFIED = new LicenseClassifier(null, null, null);
+
     @Test
     void noneLeavesTheOrderAlone() {
-        assertNull(ProjectLicenseInfoComparators.of(OrderBy.none));
-        assertNull(ProjectLicenseInfoComparators.of(null));
+        assertNull(ProjectLicenseInfoComparators.of(OrderBy.none, NO_LICENSES_CLASSIFIED));
+        assertNull(ProjectLicenseInfoComparators.of(null, NO_LICENSES_CLASSIFIED));
+    }
+
+    @Test
+    void byLicenseMatch() {
+        final LicenseClassifier classifier = new LicenseClassifier(
+                Arrays.asList("GPL 3.0"), Arrays.asList("EPL 2.0"), Arrays.asList("Apache License, Version 2.0"));
+        final List<ProjectLicenseInfo> input = Arrays.asList(
+                dependency("org.test", "unknown", "1.0", "Some House License"),
+                dependency("org.test", "ok", "1.0", "Apache License, Version 2.0"),
+                dependency("org.test", "unlicensed", "1.0"),
+                dependency("org.test", "problematic", "1.0", "EPL 2.0"),
+                dependency("org.test", "forbidden", "1.0", "GPL 3.0"),
+                dependency("org.test", "both", "1.0", "Apache License, Version 2.0", "GPL 3.0"));
+
+        final List<ProjectLicenseInfo> actual = new ArrayList<>(input);
+        actual.sort(ProjectLicenseInfoComparators.of(OrderBy.licenseMatch, classifier));
+
+        assertEquals(
+                Arrays.asList(
+                        "org.test:both:1.0",
+                        "org.test:forbidden:1.0",
+                        "org.test:problematic:1.0",
+                        "org.test:ok:1.0",
+                        "org.test:unknown:1.0",
+                        "org.test:unlicensed:1.0"),
+                actual.stream().map(ProjectLicenseInfo::toGavString).collect(Collectors.toList()));
     }
 
     @Test
@@ -114,7 +143,8 @@ class ProjectLicenseInfoComparatorsTest {
     }
 
     private static void assertOrder(OrderBy orderBy, List<ProjectLicenseInfo> input, String... expected) {
-        final Comparator<ProjectLicenseInfo> comparator = ProjectLicenseInfoComparators.of(orderBy);
+        final Comparator<ProjectLicenseInfo> comparator =
+                ProjectLicenseInfoComparators.of(orderBy, NO_LICENSES_CLASSIFIED);
         final List<ProjectLicenseInfo> actual = new ArrayList<>(input);
         actual.sort(comparator);
         assertEquals(

--- a/src/test/java/org/codehaus/mojo/license/download/LicenseClassifierTest.java
+++ b/src/test/java/org/codehaus/mojo/license/download/LicenseClassifierTest.java
@@ -1,0 +1,91 @@
+package org.codehaus.mojo.license.download;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2026 Codehaus
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.codehaus.mojo.license.download.LicenseClassifier.LicenseMatch;
+import org.codehaus.mojo.license.extended.ExtendedInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LicenseClassifierTest {
+
+    private static final LicenseClassifier CLASSIFIER = new LicenseClassifier(
+            Arrays.asList("GPL 3.0", " AGPL 3.0 "),
+            Collections.singletonList("EPL 2.0"),
+            Arrays.asList("Apache License, Version 2.0", null, "  "));
+
+    @Test
+    void classifiesByList() {
+        assertEquals(LicenseMatch.forbidden, CLASSIFIER.classify(license("GPL 3.0")));
+        assertEquals(LicenseMatch.problematic, CLASSIFIER.classify(license("EPL 2.0")));
+        assertEquals(LicenseMatch.ok, CLASSIFIER.classify(license("Apache License, Version 2.0")));
+        assertEquals(LicenseMatch.unknown, CLASSIFIER.classify(license("Some House License")));
+    }
+
+    @Test
+    void ignoresCaseAndSurroundingWhitespace() {
+        assertEquals(LicenseMatch.forbidden, CLASSIFIER.classify(license("  gpl 3.0")));
+        assertEquals(LicenseMatch.forbidden, CLASSIFIER.classify(license("AGPL 3.0")));
+        assertEquals(LicenseMatch.ok, CLASSIFIER.classify(license("APACHE LICENSE, VERSION 2.0 ")));
+    }
+
+    @Test
+    void treatsMissingLicensesAsUnknown() {
+        assertEquals(LicenseMatch.unknown, CLASSIFIER.classify((ProjectLicense) null));
+        assertEquals(LicenseMatch.unknown, CLASSIFIER.classify(license(null)));
+        assertEquals(LicenseMatch.unknown, CLASSIFIER.classify(dependency()));
+    }
+
+    @Test
+    void classifiesADependencyByItsMostWorryingLicense() {
+        assertEquals(LicenseMatch.forbidden, CLASSIFIER.classify(dependency("Apache License, Version 2.0", "GPL 3.0")));
+        assertEquals(LicenseMatch.problematic, CLASSIFIER.classify(dependency("EPL 2.0", "Some House License")));
+        assertEquals(
+                LicenseMatch.ok, CLASSIFIER.classify(dependency("Some House License", "Apache License, Version 2.0")));
+    }
+
+    @Test
+    void isEmptyWithoutAnyConfiguredName() {
+        assertTrue(new LicenseClassifier(null, null, null).isEmpty());
+        assertTrue(new LicenseClassifier(Collections.emptyList(), null, Arrays.asList(null, " ")).isEmpty());
+        assertFalse(CLASSIFIER.isEmpty());
+    }
+
+    private static ProjectLicense license(String name) {
+        return new ProjectLicense(name, null, null, null, null);
+    }
+
+    private static ProjectLicenseInfo dependency(String... licenseNames) {
+        final ProjectLicenseInfo info = new ProjectLicenseInfo("org.test", "test", "1.0", (ExtendedInfo) null);
+        for (String licenseName : licenseNames) {
+            info.addLicense(license(licenseName));
+        }
+        return info;
+    }
+}


### PR DESCRIPTION
Adds `forbiddenLicenses`, `problematicLicenses` and `okLicenses` to the license download goals, and an `orderBy` value of `licenseMatch` that puts the dependencies whose licenses need attention at the top. A dependency offering more than one license is classified by the most worrying of them, so an Apache-or-GPL dual license does not file itself away as approved.

Names are matched ignoring case and surrounding whitespace. `licenseMerges` is the right place to unify spellings, but it cannot be relied on to have run first, and an unmatched name fails silently as `unknown`.

**Based on #730** — review that one first; this branch targets it, and GitHub will retarget this PR to master once #730 merges.

The lists only affect the order for now. The highlighting they were designed for, in the Excel and Calc files, follows in a third PR: `CalcFileWriter` lives in `src/main/java11` since #684 and needs its own handling.

Reimplemented from #622 against current master, at @Master-Code-Programmer's design. Two differences: the forbidden list is its own parameter instead of reusing `excludedLicenses` from `add-third-party`, which also fails the build, and classification is a plain class with its own tests rather than a static method reachable only through the spreadsheet writers.

No new ITs. `download-licenses-configured` gains an execution whose three lists are deliberately upside down, so the expected order is the reverse of the order the dependencies resolve in and the IT fails if the ordering is ignored. The forbidden entry is spelled in lower case there, which exercises the case-insensitive matching through real plugin configuration.

Verified: `mvn verify -Prun-its -Dinvoker.test=download-licenses-configured` passes; `mvn test` is 89 tests green.

*This change was created with AI assistance.*