### PR TITLE
Trim the license names in includedLicenses and excludedLicenses

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/utils/StringToList.java
+++ b/src/main/java/org/codehaus/mojo/license/utils/StringToList.java
@@ -73,7 +73,24 @@ public class StringToList {
         return data;
     }
 
+    /**
+     * Adds one license name, dropping the whitespace around it and ignoring it when there is nothing else left.
+     *
+     * <p>The names arrive straight out of the POM, so they carry whatever the XML formatter left behind. A list
+     * whose entries are long enough gets broken over several lines, either by hand or by a formatter:
+     *
+     * <pre>
+     * &lt;includedLicenses&gt;
+     *   Apache License 2.0
+     *   |MIT License
+     * &lt;/includedLicenses&gt;
+     * </pre>
+     *
+     * @param data the license name
+     */
     protected void addEntryToList(String data) {
-        this.data.add(data);
+        if (StringUtils.isNotBlank(data)) {
+            this.data.add(data.trim());
+        }
     }
 }

--- a/src/test/java/org/codehaus/mojo/license/utils/StringToListTest.java
+++ b/src/test/java/org/codehaus/mojo/license/utils/StringToListTest.java
@@ -1,0 +1,56 @@
+package org.codehaus.mojo.license.utils;
+
+/*
+ * #%L
+ * License Maven Plugin
+ * %%
+ * Copyright (C) 2026 Codehaus
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StringToListTest {
+
+    @Test
+    void splitsOnThePipe() throws MojoExecutionException {
+        assertEquals(
+                Arrays.asList("Apache License 2.0", "MIT License"),
+                new StringToList("Apache License 2.0|MIT License").getData());
+    }
+
+    @Test
+    void dropsTheWhitespaceAnXmlFormatterLeavesBehind() throws MojoExecutionException {
+        assertEquals(
+                Arrays.asList("Apache License 2.0", "MIT License", "EPL 2.0"),
+                new StringToList("\n    Apache License 2.0\n    |MIT License\n    | EPL 2.0\n  ").getData());
+    }
+
+    @Test
+    void ignoresEmptyEntries() throws MojoExecutionException {
+        // An empty list used to hold one entry, the empty string, which matches no license.
+        assertEquals(0, new StringToList("").getData().size());
+        assertEquals(0, new StringToList("   ").getData().size());
+        assertEquals(Collections.singletonList("MIT License"), new StringToList("|MIT License|").getData());
+    }
+}


### PR DESCRIPTION
The pipe-separated form of `includedLicenses` and `excludedLicenses` only tolerated whitespace around the separator, so the first and last name in a list broken over several lines kept the indentation the XML gave them and matched nothing:

```xml
<includedLicenses>
  Apache License 2.0
  |MIT License
</includedLicenses>
```

That form is not just a matter of taste. An XML formatter breaks a long enough value over several lines on its own.

Extracted from #622, where @Master-Code-Programmer reported it. Trimming in `addEntryToList` covers the element-per-license form too, where the whitespace comes from the same place.

One behaviour change beyond the fix: an empty value used to produce a list holding the empty string, which matched no license, and now produces an empty list.

Verified: the new `StringToListTest` fails on master on both counts.

*This change was created with AI assistance.*