### PR TITLE
Fixed license name splitting

### DIFF
--- a/src/main/java/org/codehaus/mojo/license/download/LicensedArtifactResolver.java
+++ b/src/main/java/org/codehaus/mojo/license/download/LicensedArtifactResolver.java
@@ -220,14 +220,9 @@ public class LicensedArtifactResolver {
         final Map<String, String> mergedLicenses = new HashMap<>();
         if (licenseMerges != null) {
             for (String licenseMerge : licenseMerges) {
-                String[] splited = licenseMerge
-                        .trim()
-                        // Replace newlines
-                        .replace('\n', ' ')
-                        // Replace multiple spaces with one.
-                        .replaceAll(" +", " ")
-                        .split(StringToList.LIST_OF_LICENSES_REG_EX);
+                String[] splited = StringToList.trimmedStringSplit(licenseMerge);
                 for (String split : splited) {
+                    // Map other occurrences to first occurrence.
                     mergedLicenses.put(split, splited[0]);
                 }
             }

--- a/src/main/java/org/codehaus/mojo/license/utils/StringToList.java
+++ b/src/main/java/org/codehaus/mojo/license/utils/StringToList.java
@@ -38,7 +38,7 @@ import org.apache.maven.plugin.MojoExecutionException;
  */
 public class StringToList {
     /**
-     * Regular expression to split license list.
+     * Regular expression to split license list with a pipe character: "|".
      */
     public static final String LIST_OF_LICENSES_REG_EX = "\\s*\\|\\s*";
 
@@ -57,7 +57,8 @@ public class StringToList {
     public StringToList(String data) throws MojoExecutionException {
         this();
         if (!UrlRequester.isStringUrl(data)) {
-            for (String s : data.split(LIST_OF_LICENSES_REG_EX)) {
+            String[] splited = trimmedStringSplit(data);
+            for (String s : splited) {
                 addEntryToList(s);
             }
         } else {
@@ -67,6 +68,37 @@ public class StringToList {
                 }
             }
         }
+    }
+
+    /**
+     * Splits a String by the pipe character and trims it.<br>
+     * It allows, for example, to write lengthy license merge lists not written as a 400 characters long, hard to read
+     * line, but as a list of lines separated by a pipe character.<br>
+     * Example, instead of writing the following XML:
+     * <pre><code>
+     * <tag>Righteous license 2.1|The righteous extra long named super rights granting license version 2.1|Hidden right license 2.1|The completely unfair "all your rights belong to us" license version 2.1</tag>
+     * </code></pre>
+     * write:
+     * <pre><code>
+     * <tag>Righteous license 2.1
+     *     |The righteous extra long named super rights granting
+     *      license version 2.1
+     *     |Hidden right license 2.1
+     *     |The completely unfair "all your rights belong to us"
+     *      license version 2.1
+     * </tag>
+     * </code></pre>
+     * @param stringToSplit String to split.
+     * @return Split and trimmed string.
+     */
+    public static String[] trimmedStringSplit(String stringToSplit) {
+        return stringToSplit
+                .trim()
+                // Replace newlines
+                .replace('\n', ' ')
+                // Replace multiple spaces with one.
+                .replaceAll(" +", " ")
+                .split(LIST_OF_LICENSES_REG_EX);
     }
 
     public List<String> getData() {

--- a/src/test/java/org/codehaus/mojo/license/utils/StringToListTest.java
+++ b/src/test/java/org/codehaus/mojo/license/utils/StringToListTest.java
@@ -43,7 +43,7 @@ class StringToListTest {
     void dropsTheWhitespaceAnXmlFormatterLeavesBehind() throws MojoExecutionException {
         assertEquals(
                 Arrays.asList("Apache License 2.0", "MIT License", "EPL 2.0"),
-                new StringToList("\n    Apache License 2.0\n    |MIT License\n    | EPL 2.0\n  ").getData());
+                new StringToList("\n    Apache License\n    2.0\n    |MIT License\n    | EPL 2.0\n  ").getData());
     }
 
     @Test


### PR DESCRIPTION
@slachiewicz This is a fix for #734 (broken License Merge Names).

I reintroduced my own code to fix the bug.
If I quote your PR the problem becomes clearer:
> An XML formatter breaks a long enough value over several lines on its own.

That means
```java
        Hello World License in latest Amazing Blue 2.0
        |This is it License
```
may become
```java
        Hello World License 
        in latest Amazing Blue 2.0
        |This is it License
```
Where a simple trimming solution fails. The pipe (|) has to my knowledge no special meaning in XML strings, and therefore the formatter won't break reliably at only that character, but mid-license.

I changed your `dropsTheWhitespaceAnXmlFormatterLeavesBehind` test from:
```java
assertEquals(
  Arrays.asList("Apache License 2.0", "MIT License", "EPL 2.0"),
  new StringToList("\n    Apache License 2.0\n    |MIT License\n    | EPL 2.0\n  ").getData());
```
to:
```java
assertEquals(
  Arrays.asList("Apache License 2.0", "MIT License", "EPL 2.0"),
  new StringToList("\n    Apache License\n    2.0\n    |MIT License\n    | EPL 2.0\n  ").getData());    
```
w/ Apache as a stand in for a long license name. Et voila: The test broke.
With my fix it works.

Basically I had already a working solution in `LicensedArtifactResolver.buildMergedLicenses(...)` and moved it into `StringToList`, to make it a general solution.

Conclusion: Feel free to rewrite everything, but I strongly believe that modified test must pass.