### PR TITLE
Fixed skipDevelopers in CalcFileWriter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 
     <version.httpcomponents.httpclient>4.5.14</version.httpcomponents.httpclient>
     <version.httpcomponents.httpcore>4.4.16</version.httpcomponents.httpcore>
-    <version.odfdom-java>0.12.0</version.odfdom-java>
+    <version.odfdom-java>0.13.0</version.odfdom-java>
 
     <!-- license configuration -->
     <license.useMissingFile>true</license.useMissingFile>

--- a/pom.xml
+++ b/pom.xml
@@ -311,12 +311,6 @@
       <version>5.5.1</version>
     </dependency>
 
-    <!-- LibreOffice Calc ODT export -->
-    <dependency>
-      <groupId>org.odftoolkit</groupId>
-      <artifactId>odfdom-java</artifactId>
-      <version>${version.odfdom-java}</version>
-    </dependency>
     <!-- XML APIs is needed for JDK 8, was a transitive dependency from old version of odfdom-java -->
     <dependency>
       <groupId>xml-apis</groupId>
@@ -569,6 +563,15 @@
         <jdk>[11,)</jdk>
       </activation>
 
+      <dependencies>
+        <!-- LibreOffice Calc ODS export — requires Java 11+; excluded from Java 8 compilation -->
+        <dependency>
+          <groupId>org.odftoolkit</groupId>
+          <artifactId>odfdom-java</artifactId>
+          <version>${version.odfdom-java}</version>
+        </dependency>
+      </dependencies>
+
       <build>
         <plugins>
           <plugin>
@@ -588,6 +591,21 @@
                     <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
                   </compileSourceRoots>
                   <outputDirectory>${project.build.outputDirectory}/META-INF/versions/11</outputDirectory>
+                </configuration>
+              </execution>
+              <!-- Compile Java 11+ specific test code -->
+              <execution>
+                <id>java11-test-compile</id>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <phase>test-compile</phase>
+                <configuration>
+                  <release>11</release>
+                  <compileSourceRoots>
+                    <compileSourceRoot>${project.basedir}/src/test/java11</compileSourceRoot>
+                  </compileSourceRoots>
+                  <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                 </configuration>
               </execution>
             </executions>

--- a/src/main/java11/org/codehaus/mojo/license/extended/spreadsheet/CalcFileWriter.java
+++ b/src/main/java11/org/codehaus/mojo/license/extended/spreadsheet/CalcFileWriter.java
@@ -107,7 +107,8 @@ public class CalcFileWriter {
     private static final String VALUE_TYPE_STRING = "string";
     private static final String CONFIG_TYPE_SHORT = "short";
 
-    private CalcFileWriter() {}
+    private CalcFileWriter() {
+    }
 
     public static void write(List<ProjectLicenseInfo> projectLicenseInfos, final File licensesCalcOutputFile) {
         write(projectLicenseInfos, licensesCalcOutputFile, SpreadsheetFormatting.NONE);
@@ -122,9 +123,9 @@ public class CalcFileWriter {
      * @since 2.8.0
      */
     public static void write(
-            List<ProjectLicenseInfo> projectLicenseInfos,
-            final File licensesCalcOutputFile,
-            SpreadsheetFormatting formatting) {
+        List<ProjectLicenseInfo> projectLicenseInfos,
+        final File licensesCalcOutputFile,
+        SpreadsheetFormatting formatting) {
         if (CollectionUtils.isEmpty(projectLicenseInfos)) {
             LOG.debug("Nothing to write to excel, no project data.");
             return;
@@ -146,11 +147,11 @@ public class CalcFileWriter {
             createHeader(projectLicenseInfos, spreadsheet, table);
 
             writeData(
-                    projectLicenseInfos,
-                    spreadsheet,
-                    table,
-                    convertToOdfColor(SpreadsheetUtil.ALTERNATING_ROWS_COLOR),
-                    formatting);
+                projectLicenseInfos,
+                spreadsheet,
+                table,
+                convertToOdfColor(SpreadsheetUtil.ALTERNATING_ROWS_COLOR),
+                formatting);
 
             try (OutputStream fileOut = Files.newOutputStream(licensesCalcOutputFile.toPath())) {
                 spreadsheet.save(fileOut);
@@ -169,7 +170,7 @@ public class CalcFileWriter {
 
     @SuppressWarnings("checkstyle:MethodLength")
     private static void createHeader(
-            List<ProjectLicenseInfo> projectLicenseInfos, OdfSpreadsheetDocument spreadsheet, OdfTable table) {
+        List<ProjectLicenseInfo> projectLicenseInfos, OdfSpreadsheetDocument spreadsheet, OdfTable table) {
         boolean hasExtendedInfo = false;
         for (ProjectLicenseInfo projectLicenseInfo : projectLicenseInfos) {
             if (projectLicenseInfo.getExtendedInfo() != null) {
@@ -194,109 +195,109 @@ public class CalcFileWriter {
 
         // Create Maven header cell
         createMergedCellsInRow(
-                table, MAVEN_START_COLUMN, MAVEN_END_COLUMN, mavenJarRow, "Maven information", 0, HEADER_CELL_STYLE);
+            table, MAVEN_START_COLUMN, MAVEN_END_COLUMN, mavenJarRow, "Maven information", 0, HEADER_CELL_STYLE);
 
         if (hasExtendedInfo) {
             // Create JAR header cell
             createMergedCellsInRow(
-                    table,
-                    EXTENDED_INFO_START_COLUMN,
-                    EXTENDED_INFO_END_COLUMN,
-                    mavenJarRow,
-                    "JAR Content",
-                    0,
-                    HEADER_CELL_STYLE);
+                table,
+                EXTENDED_INFO_START_COLUMN,
+                EXTENDED_INFO_END_COLUMN,
+                mavenJarRow,
+                "JAR Content",
+                0,
+                HEADER_CELL_STYLE);
         }
 
         // Create Maven "General" header
         createMergedCellsInRow(
-                table, GENERAL_START_COLUMN, GENERAL_END_COLUMN, secondHeaderRow, "General", 1, HEADER_CELL_STYLE);
+            table, GENERAL_START_COLUMN, GENERAL_END_COLUMN, secondHeaderRow, "General", 1, HEADER_CELL_STYLE);
 
         // Create Maven "Plugin ID" header
         createMergedCellsInRow(
-                table,
-                PLUGIN_ID_START_COLUMN,
-                PLUGIN_ID_END_COLUMN,
-                secondHeaderRow,
-                "Plugin ID",
-                1,
-                HEADER_CELL_STYLE);
+            table,
+            PLUGIN_ID_START_COLUMN,
+            PLUGIN_ID_END_COLUMN,
+            secondHeaderRow,
+            "Plugin ID",
+            1,
+            HEADER_CELL_STYLE);
 
         // Gap "General" <-> "Plugin ID".
         setColumnWidth(table, GENERAL_END_COLUMN, GAP_WIDTH);
 
         // Create Maven "Licenses" header
         createMergedCellsInRow(
-                table, LICENSES_START_COLUMN, LICENSES_END_COLUMN, secondHeaderRow, "Licenses", 1, HEADER_CELL_STYLE);
+            table, LICENSES_START_COLUMN, LICENSES_END_COLUMN, secondHeaderRow, "Licenses", 1, HEADER_CELL_STYLE);
 
         // Gap "Plugin ID" <-> "Licenses".
         setColumnWidth(table, PLUGIN_ID_END_COLUMN, GAP_WIDTH);
 
         // Create Maven "Developers" header
         createMergedCellsInRow(
-                table,
-                DEVELOPERS_START_COLUMN,
-                DEVELOPERS_END_COLUMN,
-                secondHeaderRow,
-                "Developers",
-                1,
-                HEADER_CELL_STYLE);
+            table,
+            DEVELOPERS_START_COLUMN,
+            DEVELOPERS_END_COLUMN,
+            secondHeaderRow,
+            "Developers",
+            1,
+            HEADER_CELL_STYLE);
 
         // Gap "Licenses" <-> "Developers".
         setColumnWidth(table, LICENSES_END_COLUMN, GAP_WIDTH);
 
         // Create Maven "Miscellaneous" header
         createMergedCellsInRow(
-                table, MISC_START_COLUMN, MISC_END_COLUMN, secondHeaderRow, "Miscellaneous", 1, HEADER_CELL_STYLE);
+            table, MISC_START_COLUMN, MISC_END_COLUMN, secondHeaderRow, "Miscellaneous", 1, HEADER_CELL_STYLE);
 
         // Gap "Developers" <-> "Miscellaneous".
         setColumnWidth(table, DEVELOPERS_END_COLUMN, GAP_WIDTH);
 
         if (hasExtendedInfo) {
             createMergedCellsInRow(
-                    table,
-                    MANIFEST_START_COLUMN,
-                    MANIFEST_END_COLUMN,
-                    secondHeaderRow,
-                    "MANIFEST.MF",
-                    1,
-                    HEADER_CELL_STYLE);
+                table,
+                MANIFEST_START_COLUMN,
+                MANIFEST_END_COLUMN,
+                secondHeaderRow,
+                "MANIFEST.MF",
+                1,
+                HEADER_CELL_STYLE);
 
             // Gap "Miscellaneous" <-> "MANIFEST.MF".
             setColumnWidth(table, DEVELOPERS_END_COLUMN, GAP_WIDTH);
 
             createMergedCellsInRow(
-                    table,
-                    INFO_NOTICES_START_COLUMN,
-                    INFO_NOTICES_END_COLUMN,
-                    secondHeaderRow,
-                    "Notices text files",
-                    1,
-                    HEADER_CELL_STYLE);
+                table,
+                INFO_NOTICES_START_COLUMN,
+                INFO_NOTICES_END_COLUMN,
+                secondHeaderRow,
+                "Notices text files",
+                1,
+                HEADER_CELL_STYLE);
 
             // Gap "MANIFEST.MF" <-> "Notice text files".
             setColumnWidth(table, MANIFEST_END_COLUMN, GAP_WIDTH);
 
             createMergedCellsInRow(
-                    table,
-                    INFO_LICENSES_START_COLUMN,
-                    INFO_LICENSES_END_COLUMN,
-                    secondHeaderRow,
-                    "License text files",
-                    1,
-                    HEADER_CELL_STYLE);
+                table,
+                INFO_LICENSES_START_COLUMN,
+                INFO_LICENSES_END_COLUMN,
+                secondHeaderRow,
+                "License text files",
+                1,
+                HEADER_CELL_STYLE);
 
             // Gap "Notice text files" <-> "License text files".
             setColumnWidth(table, INFO_NOTICES_END_COLUMN, GAP_WIDTH);
 
             createMergedCellsInRow(
-                    table,
-                    INFO_SPDX_START_COLUMN,
-                    INFO_SPDX_END_COLUMN,
-                    secondHeaderRow,
-                    "SPDX license id matched",
-                    1,
-                    HEADER_CELL_STYLE);
+                table,
+                INFO_SPDX_START_COLUMN,
+                INFO_SPDX_END_COLUMN,
+                secondHeaderRow,
+                "SPDX license id matched",
+                1,
+                HEADER_CELL_STYLE);
 
             // Gap "License text files" <-> "SPDX license matches".
             setColumnWidth(table, INFO_LICENSES_END_COLUMN, GAP_WIDTH);
@@ -310,51 +311,51 @@ public class CalcFileWriter {
         createCellsInRow(thirdHeaderRow, GENERAL_START_COLUMN, HEADER_CELL_STYLE, "Name");
         // Plugin ID
         createCellsInRow(
-                thirdHeaderRow, PLUGIN_ID_START_COLUMN, HEADER_CELL_STYLE, "Group ID", "Artifact ID", "Version");
+            thirdHeaderRow, PLUGIN_ID_START_COLUMN, HEADER_CELL_STYLE, "Group ID", "Artifact ID", "Version");
         // Licenses
         createCellsInRow(
-                thirdHeaderRow,
-                LICENSES_START_COLUMN,
-                HEADER_CELL_STYLE,
-                "Name",
-                "URL",
-                "Distribution",
-                "Comments",
-                "File");
+            thirdHeaderRow,
+            LICENSES_START_COLUMN,
+            HEADER_CELL_STYLE,
+            "Name",
+            "URL",
+            "Distribution",
+            "Comments",
+            "File");
         // Developers
         createCellsInRow(
-                thirdHeaderRow,
-                DEVELOPERS_START_COLUMN,
-                HEADER_CELL_STYLE,
-                "Id",
-                "Email",
-                "Name",
-                "Organization",
-                "Organization URL",
-                "URL",
-                "Timezone");
+            thirdHeaderRow,
+            DEVELOPERS_START_COLUMN,
+            HEADER_CELL_STYLE,
+            "Id",
+            "Email",
+            "Name",
+            "Organization",
+            "Organization URL",
+            "URL",
+            "Timezone");
         // Miscellaneous
         createCellsInRow(
-                thirdHeaderRow, MISC_START_COLUMN, HEADER_CELL_STYLE, "Inception Year", "Organization", "SCM", "URL");
+            thirdHeaderRow, MISC_START_COLUMN, HEADER_CELL_STYLE, "Inception Year", "Organization", "SCM", "URL");
 
         int headerLineCount = 3;
 
         if (hasExtendedInfo) {
             // MANIFEST.MF
             createCellsInRow(
-                    thirdHeaderRow,
-                    MANIFEST_START_COLUMN,
-                    HEADER_CELL_STYLE,
-                    "Bundle license",
-                    "Bundle vendor",
-                    "Implementation vendor");
+                thirdHeaderRow,
+                MANIFEST_START_COLUMN,
+                HEADER_CELL_STYLE,
+                "Bundle license",
+                "Bundle vendor",
+                "Implementation vendor");
             // 3 InfoFile groups: Notices, Licenses and SPDX-Licenses.
             createInfoFileCellsInRow(
-                    thirdHeaderRow,
-                    HEADER_CELL_STYLE,
-                    INFO_NOTICES_START_COLUMN,
-                    INFO_LICENSES_START_COLUMN,
-                    INFO_SPDX_START_COLUMN);
+                thirdHeaderRow,
+                HEADER_CELL_STYLE,
+                INFO_NOTICES_START_COLUMN,
+                INFO_LICENSES_START_COLUMN,
+                INFO_SPDX_START_COLUMN);
 
             createFreezePane(spreadsheet, table, getDownloadColumn(true) - 1, headerLineCount);
         } else {
@@ -366,12 +367,12 @@ public class CalcFileWriter {
 
     private static void setColumnWidth(OdfTable table, int column, int width) {
         table.getColumnByIndex(column)
-                .getOdfElement()
-                .setProperty(OdfTableColumnProperties.ColumnWidth, (width / 100) + "mm");
+            .getOdfElement()
+            .setProperty(OdfTableColumnProperties.ColumnWidth, (width / 100) + "mm");
     }
 
     private static void createFreezePane(
-            OdfSpreadsheetDocument spreadsheet, OdfTable table, int column, int lineCount) {
+        OdfSpreadsheetDocument spreadsheet, OdfTable table, int column, int lineCount) {
         // TODO: Find out why this perfect XML is ignored. Use FreezePane function from ODFToolkit after they add it.
 
         final OdfSettingsDom settingsDom;
@@ -385,13 +386,13 @@ public class CalcFileWriter {
         for (int i = 0; i < childNodes.getLength(); i++) {
             Node child = childNodes.item(i);
             if ("config:config-item-set".equals(child.getNodeName())
-                    && "ooo:view-settings".equals(((Element) child).getAttribute("config:name"))) {
+                && "ooo:view-settings".equals(((Element) child).getAttribute("config:name"))) {
 
                 NodeList subChilds = child.getChildNodes();
                 for (int j = 0; j < subChilds.getLength(); j++) {
                     Node subChild = subChilds.item(j);
                     if ("config:config-item-map-indexed".equals(subChild.getNodeName())
-                            && "Views".equals(((Element) subChild).getAttribute("config:name"))) {
+                        && "Views".equals(((Element) subChild).getAttribute("config:name"))) {
 
                         break;
                     }
@@ -404,15 +405,15 @@ public class CalcFileWriter {
         NodeList list;
         try {
             list = (NodeList) xpath.evaluate(
-                    "/office:document-settings/" + "office:settings/"
-                            + "config:config-item-set/"
-                            + "config:config-item-map-indexed/"
-                            + "config:config-item-map-entry/"
-                            + "config:config-item-map-named/"
-                            + "config:config-item-map-entry",
-                    //                    "/config:config-item-set[@config:name=\"ooo:view-settings\"]" +
-                    settingsDom,
-                    XPathConstants.NODE);
+                "/office:document-settings/" + "office:settings/"
+                    + "config:config-item-set/"
+                    + "config:config-item-map-indexed/"
+                    + "config:config-item-map-entry/"
+                    + "config:config-item-map-named/"
+                    + "config:config-item-map-entry",
+                //                    "/config:config-item-set[@config:name=\"ooo:view-settings\"]" +
+                settingsDom,
+                XPathConstants.NODE);
 
             /*
             <config:config-item config:name="HorizontalSplitMode" config:type="short">2</config:config-item>
@@ -451,7 +452,7 @@ public class CalcFileWriter {
     }
 
     private static void appendConfigItemElement(
-            ConfigConfigItemMapEntryElement entryElement, String configName, String configType, String nodeValue) {
+        ConfigConfigItemMapEntryElement entryElement, String configName, String configType, String nodeValue) {
         ConfigConfigItemElement horizontalSplitMode = null;
         if (entryElement.hasChildNodes()) {
             NodeList nodeList = entryElement.getChildNodes();
@@ -501,11 +502,11 @@ public class CalcFileWriter {
      */
     @SuppressWarnings("checkstyle:MethodLength")
     private static void writeData(
-            List<ProjectLicenseInfo> projectLicenseInfos,
-            OdfSpreadsheetDocument wb,
-            OdfTable table,
-            Color alternatingRowsColor,
-            SpreadsheetFormatting formatting) {
+        List<ProjectLicenseInfo> projectLicenseInfos,
+        OdfSpreadsheetDocument wb,
+        OdfTable table,
+        Color alternatingRowsColor,
+        SpreadsheetFormatting formatting) {
         final int firstRowIndex = 3;
         int currentRowIndex = firstRowIndex;
         final Map<Integer, OdfTableRow> rowMap = new HashMap<>();
@@ -526,12 +527,12 @@ public class CalcFileWriter {
         styleNormal.setProperty(OdfTableColumnProperties.UseOptimalColumnWidth, String.valueOf(true));
 
         final Map<LicenseMatch, String> licenseStyles =
-                createLicenseStyles(officeStyles, alternatingRowsColor, formatting);
+            createLicenseStyles(officeStyles, alternatingRowsColor, formatting);
 
         for (ProjectLicenseInfo projectInfo : projectLicenseInfos) {
             final OdfStyle cellStyle, hyperlinkStyle;
             LOG.debug(
-                    "Writing {}:{} into LibreOffice calc file", projectInfo.getGroupId(), projectInfo.getArtifactId());
+                "Writing {}:{} into LibreOffice Calc file", projectInfo.getGroupId(), projectInfo.getArtifactId());
             if (grayBackground) {
                 cellStyle = styleGray;
                 hyperlinkStyle = hyperlinkStyleGray;
@@ -547,34 +548,34 @@ public class CalcFileWriter {
             rowMap.put(currentRowIndex, currentRow);
             // Plugin ID
             createDataCellsInRow(
-                    currentRow,
-                    PLUGIN_ID_START_COLUMN,
-                    cellStyle,
-                    projectInfo.getGroupId(),
-                    projectInfo.getArtifactId(),
-                    projectInfo.getVersion());
+                currentRow,
+                PLUGIN_ID_START_COLUMN,
+                cellStyle,
+                projectInfo.getGroupId(),
+                projectInfo.getArtifactId(),
+                projectInfo.getVersion());
             // Licenses
             final CellListParameter cellListParameter = new CellListParameter(table, rowMap, cellStyle);
             CurrentRowData currentRowData = new CurrentRowData(currentRowIndex, extraRows, hasExtendedInfo);
             extraRows = addList(
-                    cellListParameter,
-                    currentRowData,
-                    LICENSES_START_COLUMN,
-                    LICENSES_COLUMNS,
-                    projectInfo.getLicenses(),
-                    (OdfTableRow licenseRow, ProjectLicense license) -> {
-                        OdfTableCell[] licenses = createDataCellsInRow(
-                                licenseRow,
-                                LICENSES_START_COLUMN,
-                                cellStyle,
-                                license.getName(),
-                                license.getUrl(),
-                                license.getDistribution(),
-                                license.getComments(),
-                                license.getFile());
-                        applyLicenseStyle(licenses[0], licenseStyles, formatting.highlight(license), grayRow);
-                        addHyperlinkIfExists(table, licenses[1], hyperlinkStyle);
-                    });
+                cellListParameter,
+                currentRowData,
+                LICENSES_START_COLUMN,
+                LICENSES_COLUMNS,
+                projectInfo.getLicenses(),
+                (OdfTableRow licenseRow, ProjectLicense license) -> {
+                    OdfTableCell[] licenses = createDataCellsInRow(
+                        licenseRow,
+                        LICENSES_START_COLUMN,
+                        cellStyle,
+                        license.getName(),
+                        license.getUrl(),
+                        license.getDistribution(),
+                        license.getComments(),
+                        license.getFile());
+                    applyLicenseStyle(licenses[0], licenseStyles, formatting.highlight(license), grayRow);
+                    addHyperlinkIfExists(table, licenses[1], hyperlinkStyle);
+                });
 
             final ExtendedInfo extendedInfo = projectInfo.getExtendedInfo();
             if (extendedInfo != null) {
@@ -582,55 +583,59 @@ public class CalcFileWriter {
                 // General
                 createDataCellsInRow(currentRow, GENERAL_START_COLUMN, cellStyle, extendedInfo.getName());
                 // Developers
-                if (!formatting.skipsDevelopers()) {
-                    currentRowData = new CurrentRowData(currentRowIndex, extraRows, hasExtendedInfo);
+                currentRowData = new CurrentRowData(currentRowIndex, extraRows, hasExtendedInfo);
+                if (formatting.skipsDevelopers()) {
+                    // Add empty cells, so it doesn't copy the previous row cell.
+                    setStyleOnEmptyCells(
+                        cellListParameter, currentRowData, DEVELOPERS_START_COLUMN, DEVELOPERS_COLUMNS);
+                } else {
                     extraRows = addList(
-                            cellListParameter,
-                            currentRowData,
-                            DEVELOPERS_START_COLUMN,
-                            DEVELOPERS_COLUMNS,
-                            extendedInfo.getDevelopers(),
-                            (OdfTableRow developerRow, Developer developer) -> {
-                                OdfTableCell[] licenses = createDataCellsInRow(
-                                        developerRow,
-                                        DEVELOPERS_START_COLUMN,
-                                        cellStyle,
-                                        developer.getId(),
-                                        developer.getEmail(),
-                                        developer.getName(),
-                                        developer.getOrganization(),
-                                        developer.getOrganizationUrl(),
-                                        developer.getUrl(),
-                                        developer.getTimezone());
-                                addHyperlinkIfExists(table, licenses[1], hyperlinkStyle, true);
-                                addHyperlinkIfExists(table, licenses[4], hyperlinkStyle);
-                                addHyperlinkIfExists(table, licenses[5], hyperlinkStyle);
-                            });
+                        cellListParameter,
+                        currentRowData,
+                        DEVELOPERS_START_COLUMN,
+                        DEVELOPERS_COLUMNS,
+                        extendedInfo.getDevelopers(),
+                        (OdfTableRow developerRow, Developer developer) -> {
+                            OdfTableCell[] developers = createDataCellsInRow(
+                                developerRow,
+                                DEVELOPERS_START_COLUMN,
+                                cellStyle,
+                                developer.getId(),
+                                developer.getEmail(),
+                                developer.getName(),
+                                developer.getOrganization(),
+                                developer.getOrganizationUrl(),
+                                developer.getUrl(),
+                                developer.getTimezone());
+                            addHyperlinkIfExists(table, developers[1], hyperlinkStyle, true);
+                            addHyperlinkIfExists(table, developers[4], hyperlinkStyle);
+                            addHyperlinkIfExists(table, developers[5], hyperlinkStyle);
+                        });
                 }
                 // Miscellaneous
                 OdfTableCell[] miscCells = createDataCellsInRow(
-                        currentRow,
-                        MISC_START_COLUMN,
-                        cellStyle,
-                        extendedInfo.getInceptionYear(),
-                        Optional.ofNullable(extendedInfo.getOrganization())
-                                .map(Organization::getName)
-                                .orElse(null),
-                        Optional.ofNullable(extendedInfo.getScm())
-                                .map(Scm::getUrl)
-                                .orElse(null),
-                        extendedInfo.getUrl());
+                    currentRow,
+                    MISC_START_COLUMN,
+                    cellStyle,
+                    extendedInfo.getInceptionYear(),
+                    Optional.ofNullable(extendedInfo.getOrganization())
+                        .map(Organization::getName)
+                        .orElse(null),
+                    Optional.ofNullable(extendedInfo.getScm())
+                        .map(Scm::getUrl)
+                        .orElse(null),
+                    extendedInfo.getUrl());
                 addHyperlinkIfExists(table, miscCells[2], hyperlinkStyle);
                 addHyperlinkIfExists(table, miscCells[3], hyperlinkStyle);
 
                 // MANIFEST.MF
                 createDataCellsInRow(
-                        currentRow,
-                        MANIFEST_START_COLUMN,
-                        cellStyle,
-                        extendedInfo.getBundleLicense(),
-                        extendedInfo.getBundleVendor(),
-                        extendedInfo.getImplementationVendor());
+                    currentRow,
+                    MANIFEST_START_COLUMN,
+                    cellStyle,
+                    extendedInfo.getBundleLicense(),
+                    extendedInfo.getBundleVendor(),
+                    extendedInfo.getImplementationVendor());
 
                 // Info files
                 if (!CollectionUtils.isEmpty(extendedInfo.getInfoFiles())) {
@@ -656,28 +661,28 @@ public class CalcFileWriter {
                     // InfoFile notices text file
                     currentRowData = new CurrentRowData(currentRowIndex, extraRows, hasExtendedInfo);
                     extraRows = addInfoFileList(
-                            cellListParameter,
-                            currentRowData,
-                            INFO_NOTICES_START_COLUMN,
-                            INFO_NOTICES_COLUMNS,
-                            notices);
+                        cellListParameter,
+                        currentRowData,
+                        INFO_NOTICES_START_COLUMN,
+                        INFO_NOTICES_COLUMNS,
+                        notices);
                     // InfoFile licenses text file
                     currentRowData = new CurrentRowData(currentRowIndex, extraRows, hasExtendedInfo);
                     extraRows = addInfoFileList(
-                            cellListParameter,
-                            currentRowData,
-                            INFO_LICENSES_START_COLUMN,
-                            INFO_LICENSES_COLUMNS,
-                            licenses);
+                        cellListParameter,
+                        currentRowData,
+                        INFO_LICENSES_START_COLUMN,
+                        INFO_LICENSES_COLUMNS,
+                        licenses);
                     // InfoFile spdx licenses text file
                     currentRowData = new CurrentRowData(currentRowIndex, extraRows, hasExtendedInfo);
                     extraRows = addInfoFileList(
-                            cellListParameter, currentRowData, INFO_SPDX_START_COLUMN, INFO_SPDX_COLUMNS, spdxs);
+                        cellListParameter, currentRowData, INFO_SPDX_START_COLUMN, INFO_SPDX_COLUMNS, spdxs);
                 } else if (cellListParameter.cellStyle != null) {
                     setStyleOnEmptyCells(
-                            cellListParameter, currentRowData, INFO_NOTICES_START_COLUMN, INFO_NOTICES_COLUMNS);
+                        cellListParameter, currentRowData, INFO_NOTICES_START_COLUMN, INFO_NOTICES_COLUMNS);
                     setStyleOnEmptyCells(
-                            cellListParameter, currentRowData, INFO_LICENSES_START_COLUMN, INFO_LICENSES_COLUMNS);
+                        cellListParameter, currentRowData, INFO_LICENSES_START_COLUMN, INFO_LICENSES_COLUMNS);
                     setStyleOnEmptyCells(cellListParameter, currentRowData, INFO_SPDX_START_COLUMN, INFO_SPDX_COLUMNS);
                 }
             } else {
@@ -690,18 +695,18 @@ public class CalcFileWriter {
             if (CollectionUtils.isNotEmpty(projectInfo.getDownloaderMessages())) {
                 currentRowData = new SpreadsheetUtil.CurrentRowData(currentRowIndex, extraRows, hasExtendedInfo);
                 extraRows = addList(
-                        cellListParameter,
-                        currentRowData,
-                        downloadColumn,
-                        SpreadsheetUtil.DOWNLOAD_MESSAGE_COLUMNS,
-                        projectInfo.getDownloaderMessages(),
-                        (OdfTableRow licenseRow, String message) -> {
-                            OdfTableCell[] licenses =
-                                    createDataCellsInRow(licenseRow, downloadColumn, cellStyle, message);
-                            if (message.matches(SpreadsheetUtil.VALID_LINK)) {
-                                addHyperlinkIfExists(table, licenses[0], hyperlinkStyle);
-                            }
-                        });
+                    cellListParameter,
+                    currentRowData,
+                    downloadColumn,
+                    SpreadsheetUtil.DOWNLOAD_MESSAGE_COLUMNS,
+                    projectInfo.getDownloaderMessages(),
+                    (OdfTableRow licenseRow, String message) -> {
+                        OdfTableCell[] licenses =
+                            createDataCellsInRow(licenseRow, downloadColumn, cellStyle, message);
+                        if (message.matches(SpreadsheetUtil.VALID_LINK)) {
+                            addHyperlinkIfExists(table, licenses[0], hyperlinkStyle);
+                        }
+                    });
             } else {
                 // Add empty cell, so it doesn't copy the previous row cell.
                 OdfTableCell cell = currentRow.getCellByIndex(downloadColumn);
@@ -719,7 +724,7 @@ public class CalcFileWriter {
      * The key of a style on a row with the alternating background is suffixed with {@code -gray}.
      */
     private static Map<LicenseMatch, String> createLicenseStyles(
-            OdfOfficeStyles officeStyles, Color alternatingRowsColor, SpreadsheetFormatting formatting) {
+        OdfOfficeStyles officeStyles, Color alternatingRowsColor, SpreadsheetFormatting formatting) {
         final Map<LicenseMatch, String> styleNames = new EnumMap<>(LicenseMatch.class);
         if (!formatting.highlights()) {
             return styleNames;
@@ -729,14 +734,14 @@ public class CalcFileWriter {
             final String name = LICENSE_CELL_STYLE_PREFIX + licenseMatch;
             createLicenseStyle(officeStyles, name, color, null, formatting.hasBorder());
             createLicenseStyle(
-                    officeStyles, name + GRAY_CELL_STYLE_SUFFIX, color, alternatingRowsColor, formatting.hasBorder());
+                officeStyles, name + GRAY_CELL_STYLE_SUFFIX, color, alternatingRowsColor, formatting.hasBorder());
             styleNames.put(licenseMatch, name);
         }
         return styleNames;
     }
 
     private static void createLicenseStyle(
-            OdfOfficeStyles officeStyles, String name, Color color, Color backgroundColor, boolean border) {
+        OdfOfficeStyles officeStyles, String name, Color color, Color backgroundColor, boolean border) {
         final OdfStyle style = officeStyles.newStyle(name, OdfStyleFamily.TableCell);
         style.setProperty(StyleTextPropertiesElement.Color, color.toString());
         style.setProperty(OdfTableColumnProperties.UseOptimalColumnWidth, String.valueOf(true));
@@ -745,7 +750,7 @@ public class CalcFileWriter {
         }
         if (border) {
             style.setProperty(
-                    StyleTableCellPropertiesElement.Border, MATCHED_LICENSE_BORDER_WIDTH + " solid " + color);
+                StyleTableCellPropertiesElement.Border, MATCHED_LICENSE_BORDER_WIDTH + " solid " + color);
         }
     }
 
@@ -758,7 +763,7 @@ public class CalcFileWriter {
      * @param gray         whether the cell is on a row with the alternating background
      */
     private static void applyLicenseStyle(
-            OdfTableCell cell, Map<LicenseMatch, String> styleNames, LicenseMatch licenseMatch, boolean gray) {
+        OdfTableCell cell, Map<LicenseMatch, String> styleNames, LicenseMatch licenseMatch, boolean gray) {
         if (licenseMatch == null) {
             return;
         }
@@ -785,24 +790,24 @@ public class CalcFileWriter {
 
     private static void autosizeColumns(OdfTable table, boolean hasExtendedInfo, int rows) {
         autosizeColumns(
-                table,
-                rows,
-                new ImmutablePair<>(GENERAL_START_COLUMN, GENERAL_END_COLUMN),
-                new ImmutablePair<>(PLUGIN_ID_START_COLUMN, PLUGIN_ID_END_COLUMN),
-                new ImmutablePair<>(LICENSES_START_COLUMN, LICENSES_END_COLUMN),
-                new ImmutablePair<>(DEVELOPERS_START_COLUMN, DEVELOPERS_END_COLUMN - 1),
-                new ImmutablePair<>(MISC_START_COLUMN + 1, MISC_END_COLUMN));
+            table,
+            rows,
+            new ImmutablePair<>(GENERAL_START_COLUMN, GENERAL_END_COLUMN),
+            new ImmutablePair<>(PLUGIN_ID_START_COLUMN, PLUGIN_ID_END_COLUMN),
+            new ImmutablePair<>(LICENSES_START_COLUMN, LICENSES_END_COLUMN),
+            new ImmutablePair<>(DEVELOPERS_START_COLUMN, DEVELOPERS_END_COLUMN - 1),
+            new ImmutablePair<>(MISC_START_COLUMN + 1, MISC_END_COLUMN));
         // The column header widths are most likely wider than the actual cells content.
         setColumnWidth(table, DEVELOPERS_END_COLUMN - 1, TIMEZONE_WIDTH);
         setColumnWidth(table, MISC_START_COLUMN, INCEPTION_YEAR_WIDTH);
         if (hasExtendedInfo) {
             autosizeColumns(
-                    table,
-                    rows,
-                    new ImmutablePair<>(MANIFEST_START_COLUMN, MANIFEST_END_COLUMN),
-                    new ImmutablePair<>(INFO_NOTICES_START_COLUMN + 2, INFO_NOTICES_END_COLUMN),
-                    new ImmutablePair<>(INFO_LICENSES_START_COLUMN + 2, INFO_LICENSES_END_COLUMN),
-                    new ImmutablePair<>(INFO_SPDX_START_COLUMN + 2, INFO_SPDX_END_COLUMN));
+                table,
+                rows,
+                new ImmutablePair<>(MANIFEST_START_COLUMN, MANIFEST_END_COLUMN),
+                new ImmutablePair<>(INFO_NOTICES_START_COLUMN + 2, INFO_NOTICES_END_COLUMN),
+                new ImmutablePair<>(INFO_LICENSES_START_COLUMN + 2, INFO_LICENSES_END_COLUMN),
+                new ImmutablePair<>(INFO_SPDX_START_COLUMN + 2, INFO_SPDX_END_COLUMN));
         }
     }
 
@@ -830,39 +835,39 @@ public class CalcFileWriter {
     }
 
     private static int addInfoFileList(
-            CellListParameter cellListParameter,
-            CurrentRowData currentRowData,
-            int startColumn,
-            int columnsToFill,
-            List<InfoFile> infoFiles) {
+        CellListParameter cellListParameter,
+        CurrentRowData currentRowData,
+        int startColumn,
+        int columnsToFill,
+        List<InfoFile> infoFiles) {
         return addList(
-                cellListParameter,
-                currentRowData,
-                startColumn,
-                columnsToFill,
-                infoFiles,
-                (OdfTableRow infoFileRow, InfoFile infoFile) -> {
-                    final String copyrightLines = Optional.ofNullable(infoFile.getExtractedCopyrightLines())
-                            .map(strings -> String.join(COPYRIGHT_JOIN_SEPARATOR, strings))
-                            .orElse(null);
-                    createDataCellsInRow(
-                            infoFileRow,
-                            startColumn,
-                            cellListParameter.getCellStyle(),
-                            // This would otherwise lead to invalid XML characters in the ODS file content.
-                            infoFile.getContent().replace("\f", "\n"),
-                            copyrightLines,
-                            infoFile.getFileName());
-                });
+            cellListParameter,
+            currentRowData,
+            startColumn,
+            columnsToFill,
+            infoFiles,
+            (OdfTableRow infoFileRow, InfoFile infoFile) -> {
+                final String copyrightLines = Optional.ofNullable(infoFile.getExtractedCopyrightLines())
+                    .map(strings -> String.join(COPYRIGHT_JOIN_SEPARATOR, strings))
+                    .orElse(null);
+                createDataCellsInRow(
+                    infoFileRow,
+                    startColumn,
+                    cellListParameter.getCellStyle(),
+                    // This would otherwise lead to invalid XML characters in the ODS file content.
+                    infoFile.getContent().replace("\f", "\n"),
+                    copyrightLines,
+                    infoFile.getFileName());
+            });
     }
 
     private static <T> int addList(
-            CellListParameter cellListParameter,
-            CurrentRowData currentRowData,
-            int startColumn,
-            int columnsToFill,
-            List<T> list,
-            BiConsumer<OdfTableRow, T> biConsumer) {
+        CellListParameter cellListParameter,
+        CurrentRowData currentRowData,
+        int startColumn,
+        int columnsToFill,
+        List<T> list,
+        BiConsumer<OdfTableRow, T> biConsumer) {
         if (!CollectionUtils.isEmpty(list)) {
             for (int i = 0; i < list.size(); i++) {
                 T type = list.get(i);
@@ -874,22 +879,22 @@ public class CalcFileWriter {
                     if (cellListParameter.getCellStyle() != null) {
                         // Style all empty left cells, in the columns left from this
                         createAndStyleCells(
-                                row,
-                                cellListParameter.getCellStyle(),
-                                new ImmutablePair<>(GENERAL_START_COLUMN, GENERAL_END_COLUMN),
-                                new ImmutablePair<>(PLUGIN_ID_START_COLUMN, PLUGIN_ID_END_COLUMN),
-                                new ImmutablePair<>(LICENSES_START_COLUMN, LICENSES_END_COLUMN));
+                            row,
+                            cellListParameter.getCellStyle(),
+                            new ImmutablePair<>(GENERAL_START_COLUMN, GENERAL_END_COLUMN),
+                            new ImmutablePair<>(PLUGIN_ID_START_COLUMN, PLUGIN_ID_END_COLUMN),
+                            new ImmutablePair<>(LICENSES_START_COLUMN, LICENSES_END_COLUMN));
                         if (currentRowData.isHasExtendedInfo()) {
                             createAndStyleCells(
-                                    row,
-                                    cellListParameter.getCellStyle(),
-                                    new ImmutablePair<>(DEVELOPERS_START_COLUMN, DEVELOPERS_END_COLUMN),
-                                    new ImmutablePair<>(MISC_START_COLUMN, MISC_END_COLUMN),
-                                    // JAR
-                                    new ImmutablePair<>(MANIFEST_START_COLUMN, MANIFEST_END_COLUMN),
-                                    new ImmutablePair<>(INFO_LICENSES_START_COLUMN, INFO_LICENSES_END_COLUMN),
-                                    new ImmutablePair<>(INFO_NOTICES_START_COLUMN, INFO_NOTICES_END_COLUMN),
-                                    new ImmutablePair<>(INFO_SPDX_START_COLUMN, INFO_SPDX_END_COLUMN));
+                                row,
+                                cellListParameter.getCellStyle(),
+                                new ImmutablePair<>(DEVELOPERS_START_COLUMN, DEVELOPERS_END_COLUMN),
+                                new ImmutablePair<>(MISC_START_COLUMN, MISC_END_COLUMN),
+                                // JAR
+                                new ImmutablePair<>(MANIFEST_START_COLUMN, MANIFEST_END_COLUMN),
+                                new ImmutablePair<>(INFO_LICENSES_START_COLUMN, INFO_LICENSES_END_COLUMN),
+                                new ImmutablePair<>(INFO_NOTICES_START_COLUMN, INFO_NOTICES_END_COLUMN),
+                                new ImmutablePair<>(INFO_SPDX_START_COLUMN, INFO_SPDX_END_COLUMN));
                         }
                     }
                     currentRowData.setExtraRows(currentRowData.getExtraRows() + 1);
@@ -912,12 +917,26 @@ public class CalcFileWriter {
      * @param columnsToFill     How many columns to set the style on, starting from 'startColumn'.
      */
     private static void setStyleOnEmptyCells(
-            CellListParameter cellListParameter, CurrentRowData currentRowData, int startColumn, int columnsToFill) {
-        OdfTableRow row = cellListParameter.getRows().get(currentRowData.getCurrentRowIndex());
-        for (int i = 0; i < columnsToFill; i++) {
-            OdfTableCell cell = row.getCellByIndex(startColumn + i);
-            cell.setValueType(VALUE_TYPE_STRING);
-            cell.getOdfElement().setStyleName(getCellStyleName(cellListParameter.getCellStyle()));
+        CellListParameter cellListParameter, CurrentRowData currentRowData, int startColumn, int columnsToFill) {
+        if (currentRowData.getExtraRows() > 0) {
+            LOG.debug(
+                "Create extra {} empty rows for empty cells.",
+                currentRowData.getExtraRows());
+        }
+        for (int rowIndex = currentRowData.getCurrentRowIndex();
+             rowIndex <= currentRowData.getCurrentRowIndex() + currentRowData.getExtraRows();
+             rowIndex++) {
+            OdfTableRow row = cellListParameter.getRows().get(rowIndex);
+            if (row == null) {
+                LOG.warn("Create row {} for empty cells, because it doesn't exist yet.", rowIndex);
+                row = cellListParameter.getSheet().appendRow();
+                cellListParameter.getRows().put(rowIndex, row);
+            }
+            for (int i = 0; i < columnsToFill; i++) {
+                OdfTableCell cell = row.getCellByIndex(startColumn + i);
+                cell.setValueType(VALUE_TYPE_STRING);
+                cell.getOdfElement().setStyleName(getCellStyleName(cellListParameter.getCellStyle()));
+            }
         }
     }
 
@@ -956,7 +975,7 @@ public class CalcFileWriter {
     }
 
     private static void addHyperlinkIfExists(
-            OdfTable table, OdfTableCell cell, OdfStyle hyperlinkStyle, boolean isEmail) {
+        OdfTable table, OdfTableCell cell, OdfStyle hyperlinkStyle, boolean isEmail) {
         if (!StringUtils.isEmpty(cell.getStringValue())) {
             try {
                 cell.getOdfElement().setStyleName(getCellStyleName(hyperlinkStyle));
@@ -967,7 +986,7 @@ public class CalcFileWriter {
                 applyHyperlink(table, cell, content, isEmail);
             } catch (IllegalArgumentException e) {
                 LOG.debug(
-                        "Can't set Hyperlink for cell value " + cell.getStringValue() + " it gets rejected as URI", e);
+                    "Can't set Hyperlink for cell value " + cell.getStringValue() + " it gets rejected as URI", e);
             }
         }
     }
@@ -982,7 +1001,7 @@ public class CalcFileWriter {
      * @return Array of created table cells.
      */
     private static OdfTableCell[] createDataCellsInRow(
-            OdfTableRow row, int startColumn, OdfStyle cellStyle, String... names) {
+        OdfTableRow row, int startColumn, OdfStyle cellStyle, String... names) {
         OdfTableCell[] result = new OdfTableCell[names.length];
         for (int i = 0; i < names.length; i++) {
             OdfTableCell cell = row.getCellByIndex(startColumn + i);
@@ -1052,13 +1071,13 @@ public class CalcFileWriter {
     }
 
     private static void createMergedCellsInRow(
-            OdfTable table,
-            int startColumn,
-            int endColumn,
-            OdfTableRow row,
-            String cellValue,
-            int rowIndex,
-            String styleName) {
+        OdfTable table,
+        int startColumn,
+        int endColumn,
+        OdfTableRow row,
+        String cellValue,
+        int rowIndex,
+        String styleName) {
         OdfTableCell cell = createCellsInRow(startColumn, endColumn, row);
         if (cell == null) {
             return;

--- a/src/test/java/org/codehaus/mojo/license/download/LicenseSummaryTest.java
+++ b/src/test/java/org/codehaus/mojo/license/download/LicenseSummaryTest.java
@@ -33,7 +33,10 @@ import org.codehaus.mojo.license.extended.ExtendedInfo;
 import org.codehaus.mojo.license.extended.InfoFile;
 import org.codehaus.mojo.license.extended.spreadsheet.CalcFileWriter;
 import org.codehaus.mojo.license.extended.spreadsheet.ExcelFileWriter;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,29 +97,7 @@ class LicenseSummaryTest {
     void testWriteReadLicenseSummary()
             throws IOException, SAXException, ParserConfigurationException, TransformerFactoryConfigurationError,
                     TransformerException {
-        List<ProjectLicenseInfo> licSummary = new ArrayList<>();
-        ProjectLicenseInfo dep1 = new ProjectLicenseInfo("org.test", "test1", "1.0", buildExtendedInfo(1));
-        ProjectLicenseInfo dep2 = new ProjectLicenseInfo("org.test", "test2", "2.0", buildExtendedInfo(2));
-        ProjectLicenseInfo dep3 = new ProjectLicenseInfo("com.test", "test3", "3.0", buildExtendedInfo(3));
-        ProjectLicenseInfo dep4 = new ProjectLicenseInfo("dk.test", "test4", "4.0", buildExtendedInfo(4));
-
-        ProjectLicense lic = new ProjectLicense();
-        lic.setName("lgpl");
-        lic.setUrl("http://www.gnu.org/licenses/lgpl-3.0.txt");
-        lic.setFile("lgpl-3.0.txt");
-        lic.setComments("lgpl version 3.0");
-        dep1.addLicense(lic);
-        dep2.addLicense(lic);
-        dep3.addLicense(lic);
-
-        dep2.addDownloaderMessage("There were server problems");
-        // Skip dependency 3, to test correct empty cell filling of ODS export.
-        dep4.addDownloaderMessage("http://google.de");
-
-        licSummary.add(dep1);
-        licSummary.add(dep2);
-        licSummary.add(dep3);
-        licSummary.add(dep4);
+        List<ProjectLicenseInfo> licSummary = createLicenseSummary();
 
         File licenseSummaryFile = File.createTempFile("licSummary", "tmp");
         LicenseSummaryWriter.writeLicenseSummary(licSummary, licenseSummaryFile, StandardCharsets.UTF_8, Eol.LF, true);
@@ -164,17 +145,66 @@ class LicenseSummaryTest {
 
         Path licensesExcelOutputFile = Files.createTempFile("licExcel", ".xlsx");
         ExcelFileWriter.write(licSummary, licensesExcelOutputFile.toFile());
+    }
 
+    private static @NonNull List<ProjectLicenseInfo> createLicenseSummary() {
+        List<ProjectLicenseInfo> licSummary = new ArrayList<>();
+        ProjectLicenseInfo dep1 = new ProjectLicenseInfo("org.test", "test1", "1.0", buildExtendedInfo(1));
+        ProjectLicenseInfo dep2 = new ProjectLicenseInfo("org.test", "test2", "2.0", buildExtendedInfo(2));
+        ProjectLicenseInfo dep3 = new ProjectLicenseInfo("com.test", "test3", "3.0", buildExtendedInfo(3));
+        ProjectLicenseInfo dep4 = new ProjectLicenseInfo("dk.test", "test4", "4.0", buildExtendedInfo(4));
+
+        ProjectLicense lic = new ProjectLicense();
+        lic.setName("lgpl");
+        lic.setUrl("http://www.gnu.org/licenses/lgpl-3.0.txt");
+        lic.setFile("lgpl-3.0.txt");
+        lic.setComments("lgpl version 3.0");
+        dep1.addLicense(lic);
+        dep2.addLicense(lic);
+        dep3.addLicense(lic);
+
+        dep2.addDownloaderMessage("There were server problems");
+        // Skip dependency 3, to test correct empty cell filling of ODS export.
+        dep4.addDownloaderMessage("http://google.de");
+
+        licSummary.add(dep1);
+        licSummary.add(dep2);
+        licSummary.add(dep3);
+        licSummary.add(dep4);
+        return licSummary;
+    }
+
+    /**
+     * Expected failure of writing a LibreOffice Calc file (ODS) on JDK < 11.
+     *
+     * @throws IOException Unexpected Calc file writing problem.
+     */
+    @Test
+    @EnabledForJreRange(max = JRE.JAVA_10)
+    void testWriteCalcFail() throws IOException {
+        List<ProjectLicenseInfo> licSummary = createLicenseSummary();
         Path licensesCalcOutputFile = Files.createTempFile("licCalc", ".ods");
-        if (JRE.currentJre().version() >= 11) {
-            CalcFileWriter.write(licSummary, licensesCalcOutputFile.toFile());
-        } else {
-            // on JDK 8 this should throw an UnsupportedOperationException
-            UnsupportedOperationException exception = assertThrows(
-                    UnsupportedOperationException.class,
-                    () -> CalcFileWriter.write(licSummary, licensesCalcOutputFile.toFile()));
-            assertEquals("Write LibreOffice Calc file (ODS) requires JDK 11+", exception.getMessage());
-        }
+
+        // on JDK < 11 this should throw an UnsupportedOperationException
+        UnsupportedOperationException exception = assertThrows(
+                UnsupportedOperationException.class,
+                () -> CalcFileWriter.write(licSummary, licensesCalcOutputFile.toFile()));
+        assertEquals("Write LibreOffice Calc file (ODS) requires JDK 11+", exception.getMessage());
+    }
+
+    /**
+     * Expected success of writing a LibreOffice Calc file (ODS) on JDK >= 11.
+     *
+     * @throws IOException Unexpected Calc file writing problem.
+     */
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_11)
+    void testWriteCalcSuccess() throws IOException {
+        List<ProjectLicenseInfo> licSummary = createLicenseSummary();
+        Path licensesCalcOutputFile = Files.createTempFile("licCalc", ".ods");
+        Assertions.assertDoesNotThrow(
+                () -> CalcFileWriter.write(licSummary, licensesCalcOutputFile.toFile()),
+                String.format("JRE version %d.", JRE.currentJre().version()));
     }
 
     /**

--- a/src/test/java11/org/codehaus/mojo/license/extended/spreadsheet/CalcFileWriterTest.java
+++ b/src/test/java11/org/codehaus/mojo/license/extended/spreadsheet/CalcFileWriterTest.java
@@ -43,6 +43,7 @@ import org.odftoolkit.odfdom.dom.style.OdfStyleFamily;
 import org.odftoolkit.odfdom.incubator.doc.style.OdfStyle;
 import org.odftoolkit.odfdom.type.Color;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -87,7 +88,9 @@ class CalcFileWriterTest {
         final List<ProjectLicenseInfo> dependencies = Arrays.asList(
                 dependency("forbidden", FORBIDDEN), dependency("ok", OK), dependency("unclassified", UNCLASSIFIED));
         final File file = new File(tempDir, "licenses-" + name + ".ods");
-        CalcFileWriter.write(dependencies, file, formatting);
+        assertDoesNotThrow(
+                () -> CalcFileWriter.write(dependencies, file, formatting),
+                String.format("JRE version %d.", JRE.currentJre().version()));
         return file;
     }
 


### PR DESCRIPTION
Because the ODF / ODS exporter (or LibreOffice?) copies the styles of empty cells from the row above, empty cells must be explicitly written as that: Cells w/o content or style. Otherwise you may end up with a dozen greenly backgrounded header lines.

I reintroduced that from my code into your code for the skipDevelopers part. There are still same strange behaviors with empty cells, but this solution solves so far only the newly introduced bug, which appears with skip-developers.

Calc export w/o my fix:
<img width="764" height="300" alt="Calc Export without Fix " src="https://github.com/user-attachments/assets/e730d1e8-9375-43fc-962d-53a7c4c25831" />
Calc export w/ my fix:
<img width="764" height="300" alt="Calc Export with Fix" src="https://github.com/user-attachments/assets/d4575f79-fe80-48b0-b48b-b9dcc7b803f4" />

P.S.: I also fixed one wrong variable name and applied spotless (meaning, for a comparison "Hide whitespaces" should be selected in GitHub).

P.P.S.: I also tried to fix other already existing ODS bugs, but the ODF-Toolkit for ODS seems bad, compare to Apache POI, and far out of the scope of a small correction.